### PR TITLE
Added the external code coverage for scrutinizer on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,7 @@ matrix:
 
 before_script: composer install -n
 
-script: phpunit
+script: phpunit -v --coverage-clover=coverage.clover
+
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover


### PR DESCRIPTION
The external code coverage is enabled in the scrutinizer config, but you don't send it form Travis, making all Scrutinizer inspections timeout
