### PR TITLE
Show correct subject in exception message

### DIFF
--- a/src/Assert/Assert.php
+++ b/src/Assert/Assert.php
@@ -270,14 +270,14 @@ class Assert
     {
         self::string($path, 'The path must be a string. Got: %s');
         self::notEmpty($path, 'The path must not be empty.');
-        self::startsWith($path, '/', 'The path %2$s is not absolute.');
+        self::startsWith($path, '/', 'The path %1$s is not absolute.');
     }
 
     public static function glob($glob)
     {
         self::string($glob, 'The glob must be a string. Got: %s');
         self::notEmpty($glob, 'The glob must not be empty.');
-        self::startsWith($glob, '/', 'The glob %2$s is not absolute.');
+        self::startsWith($glob, '/', 'The glob %1$s is not absolute.');
     }
 
     public static function toString($value)

--- a/tests/Assert/AssertTest.php
+++ b/tests/Assert/AssertTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the puli/repository package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Puli\Repository\Tests\Assert;
+
+use PHPUnit_Framework_TestCase;
+use Puli\Repository\Assert\Assert;
+
+/**
+ * @since  1.0
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class AssertTest extends PHPUnit_Framework_TestCase
+{
+    public function providePath()
+    {
+        return array(
+            array('/path/to', null),
+            array(new \stdClass, 'The path must be a string. Got: stdClass'),
+            array('', 'The path must not be empty'),
+            array('not/absolute', 'The path "not/absolute" is not absolute'),
+        );
+    }
+
+    /**
+     * @dataProvider providePath
+     */
+    public function testPath($path, $expectedExceptionMessage = null)
+    {
+        if ($expectedExceptionMessage) {
+            $this->setExpectedException('InvalidArgumentException', $expectedExceptionMessage);
+        }
+
+        Assert::path($path);
+    }
+
+    public function provideGlob()
+    {
+        return array(
+            array('/glob/to', null),
+            array(new \stdClass, 'The glob must be a string. Got: stdClass'),
+            array('', 'The glob must not be empty'),
+            array('not/absolute', 'The glob "not/absolute" is not absolute'),
+        );
+    }
+
+    /**
+     * @dataProvider provideGlob
+     */
+    public function testGlob($glob, $expectedExceptionMessage = null)
+    {
+        if ($expectedExceptionMessage) {
+            $this->setExpectedException('InvalidArgumentException', $expectedExceptionMessage);
+        }
+
+        Assert::glob($glob);
+    }
+}


### PR DESCRIPTION
The Assert:path currenly shows:

````
The path "/" is not absolute.
````

when it should say

````
The path "foo/bar" is not absolute.
````