### PR TITLE
Show mount points when listing composite repositories

### DIFF
--- a/src/Resource/CompositeResource.php
+++ b/src/Resource/CompositeResource.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the puli/repository package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Puli\Repository\Resource;
+
+/**
+ * Represents a composite resource
+ *
+ * @since  1.0
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class CompositeResource extends GenericResource
+{
+}

--- a/tests/CompositeRepositoryTest.php
+++ b/tests/CompositeRepositoryTest.php
@@ -467,6 +467,24 @@ class CompositeRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->repo->listChildren('/webmozart/path/to/dir'));
     }
 
+    public function testListChildrenWithMountPoints()
+    {
+        $repo = $this->getMock('Puli\Repository\Api\ResourceRepository');
+        $resource1 = new TestFile('/');
+
+        $this->repo->mount('/foobar', $repo);
+        $repo->expects($this->once())
+            ->method('get')
+            ->with('/')
+            ->will($this->returnValue($resource1));
+
+        $expected = new ArrayResourceCollection(array(
+            $resource1->createReference('/foobar'),
+        ));
+
+        $this->assertEquals($expected, $this->repo->listChildren('/'));
+    }
+
     public function testListRootDirectory()
     {
         $repo = $this->getMock('Puli\Repository\Api\ResourceRepository');


### PR DESCRIPTION
This PR is an incomplete POC and aims to enable the listing of mount points in composite repositories.

For example if I do:

````php
$compRepo->mount('/foobar', $fooRepo);
$compRepo->mount('/foobar/barfoo', $barfooRepo);
$compRepo->mount('/dab', $dabRepo);
````

Then I would expect to see `foobar` and `dab` when doing:

````php
$compRepo->listChildren('/'); // show both foobar and dab as children
````

In addition, retrieving the root resource (`/`) when no mountpoint has been set (at `/`) will return a `CompositeResource` resource.

Does it make sense?