### PR TITLE
Fix build on Windows

### DIFF
--- a/src/Resource/AbstractFilesystemResource.php
+++ b/src/Resource/AbstractFilesystemResource.php
@@ -37,7 +37,7 @@ abstract class AbstractFilesystemResource extends GenericResource implements Fil
     {
         parent::__construct($path);
 
-        $this->filesystemPath = $filesystemPath;
+        $this->filesystemPath = str_replace(DIRECTORY_SEPARATOR, '/', $filesystemPath);
     }
 
     /**

--- a/tests/AbstractFilesystemRepositoryTest.php
+++ b/tests/AbstractFilesystemRepositoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the puli/repository package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Puli\Repository\Tests;
+
+/**
+ * @since  1.0
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+abstract class AbstractFilesystemRepositoryTest extends AbstractEditableRepositoryTest
+{
+    protected function assertPathsAreEqual($expected, $actual)
+    {
+        $normalize = function ($path) {
+            return str_replace(DIRECTORY_SEPARATOR, '/', $path);
+        };
+
+        $this->assertEquals($normalize($expected), $normalize($actual));
+    }
+}

--- a/tests/FilesystemRepositoryAbsoluteSymlinkTest.php
+++ b/tests/FilesystemRepositoryAbsoluteSymlinkTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Filesystem\Filesystem;
  * @since  1.0
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepositoryTest
+class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractFilesystemRepositoryTest
 {
     private $tempBaseDir;
 
@@ -90,7 +90,7 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
         $this->writeRepo->add('/webmozart/dir', new DirectoryResource($this->tempFixtures.'/dir1'));
 
         $this->assertTrue(is_link($this->tempDir.'/webmozart/dir'));
-        $this->assertSame($this->tempFixtures.'/dir1', readlink($this->tempDir.'/webmozart/dir'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1', readlink($this->tempDir.'/webmozart/dir'));
     }
 
     public function testOverwriteDirectoryWithDirectoryTurnsSymlinkIntoDirectory()
@@ -103,11 +103,11 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
 
         // Directories are merged
         $this->assertTrue(is_link($this->tempDir.'/webmozart/dir/file1'));
-        $this->assertSame($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/dir/file1'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/dir/file1'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/dir/file2'));
-        $this->assertSame($this->tempFixtures.'/dir2/file2', readlink($this->tempDir.'/webmozart/dir/file2'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir2/file2', readlink($this->tempDir.'/webmozart/dir/file2'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/dir/file3'));
-        $this->assertSame($this->tempFixtures.'/dir2/file3', readlink($this->tempDir.'/webmozart/dir/file3'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir2/file3', readlink($this->tempDir.'/webmozart/dir/file3'));
     }
 
     public function testOverwriteDirectoryWithDirectoryMergesSubdirectories()
@@ -121,11 +121,11 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
         // Subdirectories are merged
         $this->assertTrue(is_dir($this->tempDir.'/webmozart/dir/sub'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/dir/sub/file1'));
-        $this->assertSame($this->tempFixtures.'/dir3/sub/file1', readlink($this->tempDir.'/webmozart/dir/sub/file1'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir3/sub/file1', readlink($this->tempDir.'/webmozart/dir/sub/file1'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/dir/sub/file2'));
-        $this->assertSame($this->tempFixtures.'/dir4/sub/file2', readlink($this->tempDir.'/webmozart/dir/sub/file2'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir4/sub/file2', readlink($this->tempDir.'/webmozart/dir/sub/file2'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/dir/sub/file3'));
-        $this->assertSame($this->tempFixtures.'/dir4/sub/file3', readlink($this->tempDir.'/webmozart/dir/sub/file3'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir4/sub/file3', readlink($this->tempDir.'/webmozart/dir/sub/file3'));
     }
 
     public function testOverwriteDirectoryWithFileReplacesSymlink()
@@ -134,7 +134,7 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
         $this->writeRepo->add('/webmozart/path', new FileResource($this->tempFixtures.'/dir1/file1'));
 
         $this->assertTrue(is_link($this->tempDir.'/webmozart/path'));
-        $this->assertSame($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/path'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/path'));
     }
 
     public function testAddFileCreatesSymlink()
@@ -142,7 +142,7 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
         $this->writeRepo->add('/webmozart/file', new FileResource($this->tempFixtures.'/dir1/file2'));
 
         $this->assertTrue(is_link($this->tempDir.'/webmozart/file'));
-        $this->assertSame($this->tempFixtures.'/dir1/file2', readlink($this->tempDir.'/webmozart/file'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1/file2', readlink($this->tempDir.'/webmozart/file'));
     }
 
     public function testOverwriteFileWithDirectoryReplacesSymlink()
@@ -151,7 +151,7 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
         $this->writeRepo->add('/webmozart/path', new DirectoryResource($this->tempFixtures.'/dir1'));
 
         $this->assertTrue(is_link($this->tempDir.'/webmozart/path'));
-        $this->assertSame($this->tempFixtures.'/dir1', readlink($this->tempDir.'/webmozart/path'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1', readlink($this->tempDir.'/webmozart/path'));
     }
 
     public function testOverwriteFileWithFileReplacesSymlink()
@@ -160,7 +160,7 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
         $this->writeRepo->add('/webmozart/path', new FileResource($this->tempFixtures.'/dir1/file1'));
 
         $this->assertTrue(is_link($this->tempDir.'/webmozart/path'));
-        $this->assertSame($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/path'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/path'));
     }
 
     public function testAddSubDirectoryTurnsParentSymlinkIntoDirectory()
@@ -173,11 +173,11 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
 
         // Directories are merged
         $this->assertTrue(is_link($this->tempDir.'/webmozart/file1'));
-        $this->assertSame($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/file1'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/file1'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/file2'));
-        $this->assertSame($this->tempFixtures.'/dir1/file2', readlink($this->tempDir.'/webmozart/file2'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1/file2', readlink($this->tempDir.'/webmozart/file2'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/dir'));
-        $this->assertSame($this->tempFixtures.'/dir2', readlink($this->tempDir.'/webmozart/dir'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir2', readlink($this->tempDir.'/webmozart/dir'));
     }
 
     public function testAddSubFileTurnsParentSymlinkIntoDirectory()
@@ -190,11 +190,11 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
 
         // Directories are merged
         $this->assertTrue(is_link($this->tempDir.'/webmozart/file1'));
-        $this->assertSame($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/file1'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/file1'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/file2'));
-        $this->assertSame($this->tempFixtures.'/dir1/file2', readlink($this->tempDir.'/webmozart/file2'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1/file2', readlink($this->tempDir.'/webmozart/file2'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/file3'));
-        $this->assertSame($this->tempFixtures.'/dir2/file3', readlink($this->tempDir.'/webmozart/file3'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir2/file3', readlink($this->tempDir.'/webmozart/file3'));
     }
 
     public function testAddSubResourceWithBodyTurnsParentSymlinkIntoDirectory()
@@ -207,11 +207,11 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
 
         // Directories are merged
         $this->assertTrue(is_link($this->tempDir.'/webmozart/file1'));
-        $this->assertSame($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/file1'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1/file1', readlink($this->tempDir.'/webmozart/file1'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/file2'));
-        $this->assertSame($this->tempFixtures.'/dir1/file2', readlink($this->tempDir.'/webmozart/file2'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1/file2', readlink($this->tempDir.'/webmozart/file2'));
         $this->assertFalse(is_link($this->tempDir.'/webmozart/file3'));
-        $this->assertSame('some body', file_get_contents($this->tempDir.'/webmozart/file3'));
+        $this->assertPathsAreEqual('some body', file_get_contents($this->tempDir.'/webmozart/file3'));
     }
 
     public function testAddSubSubDirectoryTurnsParentSymlinkIntoDirectory()
@@ -224,11 +224,11 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
 
         // Directories are merged
         $this->assertTrue(is_link($this->tempDir.'/webmozart/sub/file1'));
-        $this->assertSame($this->tempFixtures.'/dir3/sub/file1', readlink($this->tempDir.'/webmozart/sub/file1'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir3/sub/file1', readlink($this->tempDir.'/webmozart/sub/file1'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/sub/file2'));
-        $this->assertSame($this->tempFixtures.'/dir3/sub/file2', readlink($this->tempDir.'/webmozart/sub/file2'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir3/sub/file2', readlink($this->tempDir.'/webmozart/sub/file2'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/sub/dir'));
-        $this->assertSame($this->tempFixtures.'/dir1', readlink($this->tempDir.'/webmozart/sub/dir'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir1', readlink($this->tempDir.'/webmozart/sub/dir'));
     }
 
     public function testAddSubSubFileTurnsParentSymlinkIntoDirectory()
@@ -241,11 +241,11 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
 
         // Directories are merged
         $this->assertTrue(is_link($this->tempDir.'/webmozart/sub/file1'));
-        $this->assertSame($this->tempFixtures.'/dir3/sub/file1', readlink($this->tempDir.'/webmozart/sub/file1'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir3/sub/file1', readlink($this->tempDir.'/webmozart/sub/file1'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/sub/file2'));
-        $this->assertSame($this->tempFixtures.'/dir3/sub/file2', readlink($this->tempDir.'/webmozart/sub/file2'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir3/sub/file2', readlink($this->tempDir.'/webmozart/sub/file2'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/sub/file3'));
-        $this->assertSame($this->tempFixtures.'/dir2/file3', readlink($this->tempDir.'/webmozart/sub/file3'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir2/file3', readlink($this->tempDir.'/webmozart/sub/file3'));
     }
 
     public function testAddSubSubResourceWithBodyTurnsParentSymlinkIntoDirectory()
@@ -258,9 +258,9 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractEditableRepository
 
         // Directories are merged
         $this->assertTrue(is_link($this->tempDir.'/webmozart/sub/file1'));
-        $this->assertSame($this->tempFixtures.'/dir3/sub/file1', readlink($this->tempDir.'/webmozart/sub/file1'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir3/sub/file1', readlink($this->tempDir.'/webmozart/sub/file1'));
         $this->assertTrue(is_link($this->tempDir.'/webmozart/sub/file2'));
-        $this->assertSame($this->tempFixtures.'/dir3/sub/file2', readlink($this->tempDir.'/webmozart/sub/file2'));
+        $this->assertPathsAreEqual($this->tempFixtures.'/dir3/sub/file2', readlink($this->tempDir.'/webmozart/sub/file2'));
         $this->assertFalse(is_link($this->tempDir.'/webmozart/sub/file3'));
         $this->assertSame('some body', file_get_contents($this->tempDir.'/webmozart/sub/file3'));
     }

--- a/tests/FilesystemRepositoryRelativeSymlinkTest.php
+++ b/tests/FilesystemRepositoryRelativeSymlinkTest.php
@@ -43,6 +43,10 @@ class FilesystemRepositoryRelativeSymlinkTest extends AbstractEditableRepository
             return;
         }
 
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Relative symlinks are not supported');
+        }
+
         while (false === @mkdir($this->tempBaseDir = sys_get_temp_dir().'/puli-repository/FilesystemRepositoryRelativeSymlinkTest'.rand(10000, 99999), 0777, true)) {}
 
         // Create both directories in the same directory, so that relative links

--- a/tests/Resource/AbstractFilesystemResourceTest.php
+++ b/tests/Resource/AbstractFilesystemResourceTest.php
@@ -68,7 +68,7 @@ abstract class AbstractFilesystemResourceTest extends AbstractResourceTest
         $filesystemPath = $this->getValidFilesystemPath();
         $resource = $this->createFilesystemResource($filesystemPath);
 
-        $this->assertSame($filesystemPath, $resource->getFilesystemPath());
+        $this->assertPathsAreEqual($filesystemPath, $resource->getFilesystemPath());
     }
 
     public function testAttachDoesNotChangeFilesystemPath()
@@ -77,7 +77,7 @@ abstract class AbstractFilesystemResourceTest extends AbstractResourceTest
         $resource = $this->createFilesystemResource($filesystemPath);
         $resource->attachTo($this->repo);
 
-        $this->assertSame($filesystemPath, $resource->getFilesystemPath());
+        $this->assertPathsAreEqual($filesystemPath, $resource->getFilesystemPath());
     }
 
     public function testDetachDoesNotChangeFilesystemPath()
@@ -87,7 +87,7 @@ abstract class AbstractFilesystemResourceTest extends AbstractResourceTest
         $resource->attachTo($this->repo);
         $resource->detach($this->repo);
 
-        $this->assertSame($filesystemPath, $resource->getFilesystemPath());
+        $this->assertPathsAreEqual($filesystemPath, $resource->getFilesystemPath());
     }
 
     public function testSerializeKeepsFilesystemPath()
@@ -97,6 +97,15 @@ abstract class AbstractFilesystemResourceTest extends AbstractResourceTest
 
         $deserialized = unserialize(serialize($resource));
 
-        $this->assertSame($filesystemPath, $deserialized->getFilesystemPath());
+        $this->assertPathsAreEqual($filesystemPath, $deserialized->getFilesystemPath());
+    }
+
+    protected function assertPathsAreEqual($expected, $actual)
+    {
+        $normalize = function ($path) {
+            return str_replace(DIRECTORY_SEPARATOR, '/', $path);
+        };
+
+        $this->assertEquals($normalize($expected), $normalize($actual));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/puli/issues/issues/65

* Some tests were comparing paths against PHP internal functions (like `readlink`). These still return the Windows variant of the path. That's why I introduced `assertPathsAreEqual` in some test cases.
* Relative symlinks aren't supported in PHP on Windows, marked tests as skipped on windows builds.
* The filesystem resources were storing the Windows variant of the filesystem path, meaning that comparing 2 objects (one created by a repository, one created in the test) resulted in problems. Now, the filesystem paths are also normalized.