### PR TITLE
[READY] Implement PathMappingRepository (development version of OptimizedPathMappingRepository)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The following [`ResourceRepository`] implementations are currently supported:
 * [`InMemoryRepository`]
 * [`FilesystemRepository`]
 * [`NullRepository`]
+* [`PathMappingRepository`]
+* [`OptimizedPathMappingRepository`]
 
 The following [`Resource`] implementations are currently supported:
 
@@ -89,6 +91,8 @@ All contents of this package are licensed under the [MIT license].
 [`InMemoryRepository`]: http://api.puli.io/latest/class-Puli.Repository.InMemoryRepository.html
 [`FilesystemRepository`]: http://api.puli.io/latest/class-Puli.Repository.FilesystemRepository.html
 [`NullRepository`]: http://api.puli.io/latest/class-Puli.Repository.NullRepository.html
+[`PathMappingRepository`]: http://api.puli.io/latest/class-Puli.Repository.PathMappingRepository.html
+[`OptimizedPathMappingRepository`]: http://api.puli.io/latest/class-Puli.Repository.OptimizedPathMappingRepository.html
 [`Resource`]: http://api.puli.io/latest/class-Puli.Repository.Api.Resource.Resource.html
 [`GenericResource`]: http://api.puli.io/latest/class-Puli.Repository.Resource.GenericResource.html
 [`FileResource`]: http://api.puli.io/latest/class-Puli.Repository.Resource.FileResource.html

--- a/src/AbstractPathMappingRepository.php
+++ b/src/AbstractPathMappingRepository.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the puli/repository package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Puli\Repository;
+
+use Countable;
+use Puli\Repository\Api\EditableRepository;
+use Puli\Repository\Resource\DirectoryResource;
+use Puli\Repository\Resource\FileResource;
+use Puli\Repository\Resource\GenericResource;
+use Webmozart\KeyValueStore\Api\KeyValueStore;
+use Webmozart\PathUtil\Path;
+
+/**
+ * Abstract base for Path mapping repositories.
+ *
+ * @since  1.0
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+abstract class AbstractPathMappingRepository implements EditableRepository
+{
+    /**
+     * @var KeyValueStore
+     */
+    protected $store;
+
+    /**
+     * Creates a new repository.
+     *
+     * @param KeyValueStore $store The store of all the paths.
+     */
+    public function __construct(KeyValueStore $store)
+    {
+        $this->store = $store;
+
+        $this->createRoot();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        // Subtract root
+        $removed = $this->countStore() - 1;
+
+        $this->store->clear();
+        $this->createRoot();
+
+        return $removed;
+    }
+
+    /**
+     * Recursively creates a directory for a path.
+     *
+     * @param string $path A directory path.
+     */
+    protected function ensureDirectoryExists($path)
+    {
+        if ($this->store->exists($path)) {
+            return;
+        }
+
+        // Recursively initialize parent directories
+        if ('/' !== $path) {
+            $this->ensureDirectoryExists(Path::getDirectory($path));
+        }
+
+        $this->store->set($path, null);
+    }
+
+    /**
+     * Create the repository root.
+     */
+    protected function createRoot()
+    {
+        if ($this->store->exists('/')) {
+            return;
+        }
+
+        $this->store->set('/', null);
+    }
+
+    /**
+     * Count the number of elements in the store.
+     *
+     * @return int
+     */
+    protected function countStore()
+    {
+        if ($this->store instanceof Countable) {
+            return count($this->store);
+        }
+
+        return count($this->store->keys());
+    }
+
+    /**
+     * Sort the store by keys.
+     */
+    protected function sortStore()
+    {
+        $resources = $this->store->getMultiple($this->store->keys());
+
+        ksort($resources);
+
+        $this->store->clear();
+
+        foreach ($resources as $path => $resource) {
+            $this->store->set($path, $resource);
+        }
+    }
+
+    /**
+     * Create a resource using its filesystem path.
+     *
+     * If the filesystem path is a directory, a DirectoryResource will be created.
+     * If the filesystem path is a file, a FileResource will be created.
+     * If the filesystem does not exists, a GenericResource will be created.
+     *
+     * @param string $filesystemPath The filesystem path.
+     *
+     * @return GenericResource|DirectoryResource|FileResource The created resource.
+     */
+    protected function createResource($filesystemPath)
+    {
+        if ($filesystemPath === null) {
+            return new GenericResource();
+        }
+
+        if (is_dir($filesystemPath)) {
+            return new DirectoryResource($filesystemPath);
+        } elseif (is_file($filesystemPath)) {
+            return new FileResource($filesystemPath);
+        }
+
+        return new GenericResource();
+    }
+
+    /**
+     * Create a collection of resources using a list of filesystem paths.
+     *
+     * @param array $filesystemPaths
+     *
+     * @return array
+     */
+    protected function createResources($filesystemPaths)
+    {
+        $resources = array();
+
+        foreach ($filesystemPaths as $path => $filesystemPath) {
+            $child = $this->createResource($filesystemPath);
+            $child->attachTo($this, $path);
+
+            $resources[] = $child;
+        }
+
+        return $resources;
+    }
+}

--- a/src/AbstractPathMappingRepository.php
+++ b/src/AbstractPathMappingRepository.php
@@ -12,7 +12,6 @@
 namespace Puli\Repository;
 
 use Countable;
-use Puli\Repository\Api\EditableRepository;
 use Puli\Repository\Resource\DirectoryResource;
 use Puli\Repository\Resource\FileResource;
 use Puli\Repository\Resource\GenericResource;
@@ -27,7 +26,7 @@ use Webmozart\PathUtil\Path;
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-abstract class AbstractPathMappingRepository implements EditableRepository
+abstract class AbstractPathMappingRepository extends AbstractRepository
 {
     /**
      * @var KeyValueStore

--- a/src/AbstractRepository.php
+++ b/src/AbstractRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the puli/repository package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Puli\Repository;
+
+use Puli\Repository\Api\ResourceRepository;
+use Puli\Repository\Api\UnsupportedLanguageException;
+use Webmozart\Assert\Assert;
+use Webmozart\PathUtil\Path;
+
+/**
+ * Abstract base for repositories providing tools to avoid code duplication.
+ *
+ * @since  1.0
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+abstract class AbstractRepository implements ResourceRepository
+{
+    /**
+     * Validate a language is usable to search in repositories.
+     *
+     * @param string $language
+     */
+    protected function validateSearchLanguage($language)
+    {
+        if ('glob' !== $language) {
+            throw UnsupportedLanguageException::forLanguage($language);
+        }
+    }
+
+    /**
+     * Sanitize a given path and check its validity.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    protected function sanitizePath($path)
+    {
+        Assert::stringNotEmpty($path, 'The path must be a non-empty string. Got: %s');
+        Assert::startsWith($path, '/', 'The path %s is not absolute.');
+
+        return Path::canonicalize($path);
+    }
+}

--- a/src/PathMappingRepository.php
+++ b/src/PathMappingRepository.php
@@ -1,0 +1,510 @@
+<?php
+
+/*
+ * This file is part of the puli/repository package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Puli\Repository;
+
+use Countable;
+use ArrayIterator;
+use BadMethodCallException;
+
+use Puli\Repository\Api\EditableRepository;
+use Puli\Repository\Api\Resource\FilesystemResource;
+use Puli\Repository\Api\Resource\Resource;
+use Puli\Repository\Api\ResourceCollection;
+use Puli\Repository\Api\ResourceNotFoundException;
+use Puli\Repository\Api\UnsupportedLanguageException;
+use Puli\Repository\Api\UnsupportedResourceException;
+use Puli\Repository\Resource\Collection\ArrayResourceCollection;
+use Puli\Repository\Resource\DirectoryResource;
+use Puli\Repository\Resource\FileResource;
+use Puli\Repository\Resource\GenericResource;
+
+use Webmozart\Assert\Assert;
+use Webmozart\Glob\Glob;
+use Webmozart\Glob\Iterator\RegexFilterIterator;
+use Webmozart\KeyValueStore\Api\KeyValueStore;
+use Webmozart\PathUtil\Path;
+
+/**
+ * A development path mapping resource repository.
+ * Each resource is resolved at `get()` time to improve
+ * developer experience.
+ *
+ * Resources can be added with the method {@link add()}:
+ *
+ * ```php
+ * use Puli\Repository\PathMappingRepository;
+ *
+ * $repo = new PathMappingRepository();
+ * $repo->add('/css', new DirectoryResource('/path/to/project/res/css'));
+ * ```
+ *
+ * This repository only supports instances of FilesystemResource.
+ *
+ * @since  1.0
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class PathMappingRepository implements EditableRepository
+{
+    /**
+     * @var KeyValueStore
+     */
+    private $store;
+
+    /**
+     * Creates a new repository.
+     *
+     * @param KeyValueStore $store The store of all the paths.
+     */
+    public function __construct(KeyValueStore $store)
+    {
+        $this->store = $store;
+
+        $this->createRoot();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($path)
+    {
+        Assert::stringNotEmpty($path, 'The path must be a non-empty string. Got: %s');
+        Assert::startsWith($path, '/', 'The path %s is not absolute.');
+
+        $path = Path::canonicalize($path);
+        $resource = $this->resolveResource($path);
+
+        if (!$resource) {
+            throw ResourceNotFoundException::forPath($path);
+        }
+
+        return $resource;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($query, $language = 'glob')
+    {
+        if ('glob' !== $language) {
+            throw UnsupportedLanguageException::forLanguage($language);
+        }
+
+        Assert::stringNotEmpty($query, 'The glob must be a non-empty string. Got: %s');
+        Assert::startsWith($query, '/', 'The glob %s is not absolute.');
+
+        $query = Path::canonicalize($query);
+
+        return $this->search($query, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function contains($query, $language = 'glob')
+    {
+        if ('glob' !== $language) {
+            throw UnsupportedLanguageException::forLanguage($language);
+        }
+
+        Assert::stringNotEmpty($query, 'The glob must be a non-empty string. Got: %s');
+        Assert::startsWith($query, '/', 'The glob %s is not absolute.');
+
+        $query = Path::canonicalize($query);
+
+        return $this->search($query, true)->count() > 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($path, $resource)
+    {
+        Assert::stringNotEmpty($path, 'The path must be a non-empty string. Got: %s');
+        Assert::startsWith($path, '/', 'The path %s is not absolute.');
+
+        $path = Path::canonicalize($path);
+
+        if ($resource instanceof ResourceCollection) {
+            $this->ensureDirectoryExists($path);
+
+            foreach ($resource as $child) {
+                $this->addResource($path.'/'.$child->getName(), $child);
+            }
+
+            $this->sortStore();
+
+            return;
+        }
+
+        if ($resource instanceof FilesystemResource) {
+            $this->ensureDirectoryExists(Path::getDirectory($path));
+            $this->addResource($path, $resource);
+            $this->sortStore();
+
+            return;
+        }
+
+        throw new UnsupportedResourceException(sprintf(
+            'The passed resource must be a FilesystemResource or a ResourceCollection. Got: %s',
+            is_object($resource) ? get_class($resource) : gettype($resource)
+        ));
+    }
+
+    /**
+     * Removes all resources matching the given query.
+     *
+     * This method is not supported by this repository.
+     *
+     * @param string $query    A resource query.
+     * @param string $language The language of the query. All implementations
+     *                         must support the language "glob".
+     *
+     * @return integer The number of resources removed from the repository.
+     *
+     * @throws BadMethodCallException
+     */
+    public function remove($query, $language = 'glob')
+    {
+        throw new BadMethodCallException(sprintf('%s() is not supported in %s', __METHOD__, __CLASS__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        // Subtract root
+        $removed = $this->countStore() - 1;
+
+        $this->store->clear();
+        $this->createRoot();
+
+        return $removed;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function listChildren($path)
+    {
+        return new ArrayResourceCollection($this->getChildren($this->get($path)));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasChildren($path)
+    {
+        return $this->getChildren($this->get($path))->count() !== 0;
+    }
+
+    /**
+     * Find a resource on fetch time ("resolve the resource").
+     *
+     * @param string $path The path to resolve
+     * @return \Puli\Repository\Api\Resource\Resource|null The resource or null if the resource is not found
+     */
+    private function resolveResource($path)
+    {
+        if ($this->store->exists($path)) {
+            $resolved = $this->createResource($this->store->get($path));
+            $resolved->attachTo($this, $path);
+
+            return $resolved;
+        }
+
+        $storePaths = $this->store->keys();
+
+        // Paths are sorted by length:
+        // we need to reverse the order to be more efficient
+        $storePaths = array_reverse($storePaths);
+
+        // Create regex
+        $regExpressions = array();
+
+        foreach ($storePaths as $storePath) {
+            $prefix = rtrim($storePath, '/').'/';
+            $regExpressions[] = '~^'.preg_quote($prefix, '~').'~';
+        }
+
+        // Resolve the resource using paths and children
+        $resolved = null;
+
+        foreach ($regExpressions as $key => $regExpression) {
+            if (preg_match($regExpression, $path)) {
+                // The path match, try to find if the file exists here
+                $filesystemRoot = rtrim($this->store->get($storePaths[$key]), '/') . '/';
+                $filesystemPath = preg_replace($regExpression, $filesystemRoot, $path);
+
+                $resource = $this->createResource($filesystemPath);
+
+                if ($resource instanceof FilesystemResource) {
+                    $resolved = $resource;
+                    $resolved->attachTo($this, $path);
+                    break;
+                }
+            }
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Resolve a given glob on the repository.
+     *
+     * @param string $query The glob query.
+     * @param bool $singleResult Should this method stop after finding a first result
+     * @return ArrayResourceCollection The results of search.
+     */
+    private function search($query, $singleResult = false)
+    {
+        $resources = new ArrayResourceCollection();
+
+        if (Glob::isDynamic($query)) {
+            $basePath = Glob::getBasePath($query);
+            $baseResource = $this->resolveResource($basePath);
+
+            if ($baseResource !== null) {
+                $children = $this->getChildrenRecursive($baseResource);
+
+                foreach ($children as $child) {
+                    if (Glob::match($child->getRepositoryPath(), $query)) {
+                        $resources->add($child);
+
+                        if ($singleResult) {
+                            break;
+                        }
+                    }
+                }
+            }
+        } else {
+            $resource = $this->resolveResource($query);
+
+            if ($resource instanceof Resource) {
+                $resources->add($resource);
+            }
+        }
+
+        return $resources;
+    }
+
+    /**
+     * Recursively creates a directory for a path.
+     *
+     * @param string $path A directory path.
+     * @return DirectoryResource The created resource
+     */
+    private function ensureDirectoryExists($path)
+    {
+        if ($this->store->exists($path)) {
+            return;
+        }
+
+        // Recursively initialize parent directories
+        if ('/' !== $path) {
+            $this->ensureDirectoryExists(Path::getDirectory($path));
+        }
+
+        $this->store->set($path, null);
+    }
+
+    /**
+     * Add a given resource to the repository.
+     *
+     * @param string $path
+     * @param FilesystemResource $resource
+     */
+    private function addResource($path, FilesystemResource $resource)
+    {
+        // Don't modify resources attached to other repositories
+        if ($resource->isAttached()) {
+            $resource = clone $resource;
+        }
+
+        $resource->attachTo($this, $path);
+
+        $this->store->set($path, $resource->getFilesystemPath());
+    }
+
+    /**
+     * Return the children of a given resource (explore recursively).
+     *
+     * @param \Puli\Repository\Api\Resource\Resource $resource The resource.
+     * @return ArrayResourceCollection|\Puli\Repository\Api\Resource\Resource[]
+     */
+    private function getChildrenRecursive(Resource $resource)
+    {
+        $resources = new ArrayResourceCollection();
+
+        foreach ($this->getChildren($resource) as $child) {
+            $resources->merge($this->getChildrenRecursive($child));
+        }
+
+        $resources->add($resource);
+
+        return $resources;
+    }
+
+    /**
+     * Return the children of a given resource.
+     *
+     * @param \Puli\Repository\Api\Resource\Resource $resource The resource.
+     * @return ArrayResourceCollection
+     */
+    private function getChildren(Resource $resource)
+    {
+        if ($resource instanceof FilesystemResource) {
+            $children = $this->getFilesystemResourceChildren($resource);
+        } else {
+            $children = $this->getVirtualResourceChildren($resource);
+        }
+
+        return new ArrayResourceCollection($children);
+    }
+
+    /**
+     * Return the children of a given filesystem resource.
+     *
+     * @param FilesystemResource $root
+     * @return \Puli\Repository\Api\Resource\Resource[]
+     */
+    private function getFilesystemResourceChildren(FilesystemResource $root)
+    {
+        if (!is_dir($root->getFilesystemPath())) {
+            return array();
+        }
+
+        $iterator = new \RecursiveDirectoryIterator(
+            $root->getFilesystemPath(),
+            \FilesystemIterator::CURRENT_AS_PATHNAME | \FilesystemIterator::SKIP_DOTS
+        );
+
+        $filesystemPaths = iterator_to_array($iterator);
+
+        // RecursiveDirectoryIterator is not guaranteed to return sorted results
+        sort($filesystemPaths);
+
+        $resources = array();
+
+        foreach ($filesystemPaths as $filesystemPath) {
+            $resource = $this->createResource($filesystemPath);
+
+            $path = preg_replace(
+                '~^'.preg_quote(rtrim($root->getFilesystemPath(), '/').'/', '~').'~',
+                rtrim($root->getRepositoryPath(), '/') . '/',
+                $filesystemPath
+            );
+
+            $resource->attachTo($this, $path);
+
+            $resources[] = $resource;
+        }
+
+        return $resources;
+    }
+
+    /**
+     * Return the children of a given virtual resource.
+     *
+     * @param \Puli\Repository\Api\Resource\Resource $resource The resource.
+     * @return \Puli\Repository\Api\Resource\Resource[]
+     */
+    private function getVirtualResourceChildren(Resource $resource)
+    {
+        $staticPrefix = rtrim($resource->getPath(), '/').'/';
+        $regExp = '~^'.preg_quote($staticPrefix, '~').'[^/]+$~';
+
+        $iterator = new RegexFilterIterator(
+            $regExp,
+            $staticPrefix,
+            new ArrayIterator($this->store->keys())
+        );
+
+        // Sorted on adding
+        $filesystemPaths = $this->store->getMultiple(iterator_to_array($iterator));
+
+        $resources = array();
+
+        foreach ($filesystemPaths as $path => $filesystemPath) {
+            $resource = $this->createResource($filesystemPath);
+            $resource->attachTo($this, $path);
+
+            $resources[] = $resource;
+        }
+
+        return $resources;
+    }
+
+    /**
+     * Create the repository root
+     */
+    private function createRoot()
+    {
+        if ($this->store->exists('/')) {
+            return;
+        }
+
+        $this->store->set('/', null);
+    }
+
+    /**
+     * Count the number of elements in the store
+     *
+     * @return int
+     */
+    private function countStore()
+    {
+        if ($this->store instanceof Countable) {
+            return count($this->store);
+        }
+
+        return count($this->store->keys());
+    }
+
+    /**
+     * Sort the store by keys
+     */
+    private function sortStore()
+    {
+        $resources = $this->store->getMultiple($this->store->keys());
+
+        ksort($resources);
+
+        $this->store->clear();
+
+        foreach ($resources as $path => $resource) {
+            $this->store->set($path, $resource);
+        }
+    }
+
+    /**
+     * Create a resource using its filesystem path
+     *
+     * @param string $filesystemPath
+     * @return FilesystemResource
+     */
+    private function createResource($filesystemPath)
+    {
+        if ($filesystemPath === null) {
+            return new GenericResource();
+        }
+
+        if (is_dir($filesystemPath)) {
+            return new DirectoryResource($filesystemPath);
+        } elseif (is_file($filesystemPath)) {
+            return new FileResource($filesystemPath);
+        }
+
+        return new GenericResource();
+    }
+}

--- a/src/PathMappingRepository.php
+++ b/src/PathMappingRepository.php
@@ -11,10 +11,9 @@
 
 namespace Puli\Repository;
 
-use Countable;
 use ArrayIterator;
 use BadMethodCallException;
-
+use Countable;
 use Puli\Repository\Api\EditableRepository;
 use Puli\Repository\Api\Resource\FilesystemResource;
 use Puli\Repository\Api\Resource\Resource;
@@ -26,7 +25,6 @@ use Puli\Repository\Resource\Collection\ArrayResourceCollection;
 use Puli\Repository\Resource\DirectoryResource;
 use Puli\Repository\Resource\FileResource;
 use Puli\Repository\Resource\GenericResource;
-
 use Webmozart\Assert\Assert;
 use Webmozart\Glob\Glob;
 use Webmozart\Glob\Iterator\RegexFilterIterator;
@@ -50,6 +48,7 @@ use Webmozart\PathUtil\Path;
  * This repository only supports instances of FilesystemResource.
  *
  * @since  1.0
+ *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
@@ -59,7 +58,6 @@ class PathMappingRepository implements EditableRepository
      * @var KeyValueStore
      */
     private $store;
-
 
     /**
      * Creates a new repository.
@@ -170,7 +168,7 @@ class PathMappingRepository implements EditableRepository
      * @param string $language The language of the query. All implementations
      *                         must support the language "glob".
      *
-     * @return integer The number of resources removed from the repository.
+     * @return int The number of resources removed from the repository.
      *
      * @throws BadMethodCallException
      */
@@ -209,13 +207,12 @@ class PathMappingRepository implements EditableRepository
         return $this->getChildren($this->get($path))->count() !== 0;
     }
 
-
     /**
      * Find a resource by its path.
      *
      * @param string $path The path to resolve.
      *
-     * @return Resource|null  The resource or null if the resource is not found.
+     * @return Resource|null The resource or null if the resource is not found.
      */
     private function resolveResource($path)
     {
@@ -239,39 +236,34 @@ class PathMappingRepository implements EditableRepository
          */
         $basePaths = array_reverse($this->store->keys());
 
-        $resolved = null;
-
         foreach ($basePaths as $key => $basePath) {
             if (!Path::isBasePath($basePath, $path)) {
                 continue;
             }
 
-            // The current resource is a potential parent, let's check if it's
-            // a real one by checking the filesystem
             $filesystemBasePath = rtrim($this->store->get($basePath), '/').'/';
             $filesystemPath = substr_replace($path, $filesystemBasePath, 0, strlen($basePath));
 
             $resource = $this->createResource($filesystemPath);
 
-            // The resource is resolved
             if ($resource instanceof FilesystemResource) {
-                $resolved = $resource;
-                $resolved->attachTo($this, $path);
-                break;
+                $resource->attachTo($this, $path);
+
+                return $resource;
             }
         }
 
-        return $resolved;
+        return null;
     }
 
     /**
      * Search for resources by querying their path.
      *
-     * @param string $query             The glob query.
-     * @param bool $singleResult        Should this method stop after finding a
-     *                                  first result, for performances.
+     * @param string $query        The glob query.
+     * @param bool   $singleResult Should this method stop after finding a
+     *                             first result, for performances.
      *
-     * @return ArrayResourceCollection  The results of search.
+     * @return ArrayResourceCollection The results of search.
      */
     private function search($query, $singleResult = false)
     {
@@ -341,7 +333,7 @@ class PathMappingRepository implements EditableRepository
     /**
      * Add a given resource to the repository.
      *
-     * @param string $path
+     * @param string             $path
      * @param FilesystemResource $resource
      */
     private function addResource($path, FilesystemResource $resource)
@@ -470,7 +462,7 @@ class PathMappingRepository implements EditableRepository
     }
 
     /**
-     * Create the repository root;
+     * Create the repository root.
      */
     private function createRoot()
     {

--- a/tests/AbstractEditableRepositoryTest.php
+++ b/tests/AbstractEditableRepositoryTest.php
@@ -68,8 +68,8 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testAddFile()
     {
-        $this->writeRepo->add('/webmozart/puli', $this->createDirectory());
-        $this->writeRepo->add('/webmozart/puli/file', $this->createFile());
+        $this->writeRepo->add('/webmozart/puli', $this->buildStructure($this->createDirectory()));
+        $this->writeRepo->add('/webmozart/puli/file', $this->buildStructure($this->createFile()));
 
         $dir = $this->readRepo->get('/webmozart/puli');
         $file = $this->readRepo->get('/webmozart/puli/file');
@@ -86,14 +86,15 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testAddMergesResourceChildren()
     {
-        $this->writeRepo->add('/webmozart/puli', $this->createDirectory(null, array(
+        $this->writeRepo->add('/webmozart/puli', $this->buildStructure($this->createDirectory('/merge', array(
             $this->createFile('/file1', 'original 1'),
             $this->createFile('/file2', 'original 2'),
-        )));
-        $this->writeRepo->add('/webmozart/puli', $this->createDirectory(null, array(
+        ))));
+
+        $this->writeRepo->add('/webmozart/puli', $this->buildStructure($this->createDirectory('/merge', array(
             $this->createFile('/file1', 'override 1'),
             $this->createFile('/file3', 'override 3'),
-        )));
+        ))));
 
         $dir = $this->readRepo->get('/webmozart/puli');
         $file1 = $this->readRepo->get('/webmozart/puli/file1');
@@ -121,7 +122,7 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testAddDot()
     {
-        $this->writeRepo->add('/webmozart/puli/file/.', $this->createFile());
+        $this->writeRepo->add('/webmozart/puli/file/.', $this->buildStructure($this->createFile()));
 
         $file = $this->readRepo->get('/webmozart/puli/file');
 
@@ -131,7 +132,7 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testAddDotDot()
     {
-        $this->writeRepo->add('/webmozart/puli/file/..', $this->createFile());
+        $this->writeRepo->add('/webmozart/puli/file/..', $this->buildStructure($this->createFile()));
 
         $file = $this->readRepo->get('/webmozart/puli');
 
@@ -141,7 +142,7 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testAddTrimsTrailingSlash()
     {
-        $this->writeRepo->add('/webmozart/puli/file/', $this->createFile());
+        $this->writeRepo->add('/webmozart/puli/file/', $this->buildStructure($this->createFile()));
 
         $file = $this->readRepo->get('/webmozart/puli/file');
 
@@ -152,8 +153,8 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
     public function testAddCollection()
     {
         $this->writeRepo->add('/webmozart/puli', new ArrayResourceCollection(array(
-            $this->createFile('/file1'),
-            $this->createFile('/file2'),
+            $this->buildStructure($this->createFile('/file1')),
+            $this->buildStructure($this->createFile('/file2')),
         )));
 
         $file1 = $this->readRepo->get('/webmozart/puli/file1');
@@ -168,11 +169,11 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testAddRoot()
     {
-        $this->writeRepo->add('/', $this->createDirectory('/', array(
+        $this->writeRepo->add('/', $this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createFile('/webmozart/file'),
+                $this->createFile('/file'),
             )),
-        )));
+        ))));
 
         $root = $this->readRepo->get('/');
         $dir = $this->readRepo->get('/webmozart');
@@ -199,7 +200,7 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
      */
     public function testAddExpectsAbsolutePath()
     {
-        $this->writeRepo->add('webmozart', $this->createDirectory());
+        $this->writeRepo->add('webmozart', $this->buildStructure($this->createDirectory()));
     }
 
     /**
@@ -207,7 +208,7 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
      */
     public function testAddExpectsNonEmptyPath()
     {
-        $this->writeRepo->add('', $this->createDirectory());
+        $this->writeRepo->add('', $this->buildStructure($this->createDirectory()));
     }
 
     /**
@@ -215,7 +216,7 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
      */
     public function testAddExpectsStringPath()
     {
-        $this->writeRepo->add(new \stdClass(), $this->createDirectory());
+        $this->writeRepo->add(new \stdClass(), $this->buildStructure($this->createDirectory()));
     }
 
     /**
@@ -228,8 +229,8 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testRemoveFile()
     {
-        $this->writeRepo->add('/webmozart/puli/file1', $this->createFile());
-        $this->writeRepo->add('/webmozart/puli/file2', $this->createFile());
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
 
         $this->assertTrue($this->readRepo->contains('/webmozart'));
         $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
@@ -246,8 +247,8 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testRemoveMany()
     {
-        $this->writeRepo->add('/webmozart/puli/file1', $this->createFile());
-        $this->writeRepo->add('/webmozart/puli/file2', $this->createFile());
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
 
         $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
         $this->assertTrue($this->readRepo->contains('/webmozart/puli/file1'));
@@ -273,8 +274,8 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
      */
     public function testRemoveDirectory($glob)
     {
-        $this->writeRepo->add('/webmozart/puli/file1', $this->createFile());
-        $this->writeRepo->add('/webmozart/puli/file2', $this->createFile());
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
 
         $this->assertTrue($this->readRepo->contains('/webmozart'));
         $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
@@ -291,8 +292,8 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testRemoveDot()
     {
-        $this->writeRepo->add('/webmozart/puli/file1', $this->createFile());
-        $this->writeRepo->add('/webmozart/puli/file2', $this->createFile());
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
 
         $this->assertTrue($this->readRepo->contains('/webmozart'));
         $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
@@ -309,8 +310,8 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testRemoveDotDot()
     {
-        $this->writeRepo->add('/webmozart/puli/file1', $this->createFile());
-        $this->writeRepo->add('/webmozart/puli/file2', $this->createFile());
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
 
         $this->assertTrue($this->readRepo->contains('/'));
         $this->assertTrue($this->readRepo->contains('/webmozart'));
@@ -329,8 +330,8 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testRemoveDiscardsTrailingSlash()
     {
-        $this->writeRepo->add('/webmozart/puli/file1', $this->createFile());
-        $this->writeRepo->add('/webmozart/puli/file2', $this->createFile());
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
 
         $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
         $this->assertTrue($this->readRepo->contains('/webmozart/puli/file1'));
@@ -385,8 +386,8 @@ abstract class AbstractEditableRepositoryTest extends AbstractRepositoryTest
 
     public function testClear()
     {
-        $this->writeRepo->add('/webmozart/puli/file1', $this->createFile());
-        $this->writeRepo->add('/webmozart/puli/file2', $this->createFile());
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
 
         $this->assertTrue($this->readRepo->contains('/'));
         $this->assertTrue($this->readRepo->contains('/webmozart'));

--- a/tests/AbstractRepositoryTest.php
+++ b/tests/AbstractRepositoryTest.php
@@ -51,6 +51,18 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
         return new TestDirectory($path, $children);
     }
 
+    /**
+     * Build the real backend structure
+     *
+     * @param Resource $root
+     *
+     * @return Resource
+     */
+    protected function buildStructure(Resource $root)
+    {
+        return $root;
+    }
+
     protected function pass()
     {
         $this->assertTrue(true);
@@ -58,7 +70,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testContainsPath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $this->assertTrue($repo->contains('/'));
         $this->assertTrue($repo->contains('/.'));
@@ -86,14 +98,14 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($repo->contains('/webmozart/puli/file2/.'));
         $this->assertFalse($repo->contains('/webmozart/puli/file2/..'));
 
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/file1'),
-                    $this->createFile('/webmozart/puli/file2'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/file1'),
+                    $this->createFile('/file2'),
                 )),
             )),
-        )));
+        ))));
 
         $this->assertTrue($repo->contains('/'));
         $this->assertTrue($repo->contains('/.'));
@@ -123,21 +135,21 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testContainsPattern()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $this->assertFalse($repo->contains('/webmozart/**/*'));
         $this->assertFalse($repo->contains('/webmozart/file*'));
         $this->assertFalse($repo->contains('/webmozart/puli/file*'));
         $this->assertFalse($repo->contains('/webmozart/**/file*'));
 
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/file1'),
-                    $this->createFile('/webmozart/puli/file2'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/file1'),
+                    $this->createFile('/file2'),
                 )),
             )),
-        )));
+        ))));
 
         $this->assertTrue($repo->contains('/**/*'));
         $this->assertTrue($repo->contains('/webmozart/**/*'));
@@ -149,16 +161,16 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testContainsDiscardsTrailingSlash()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart'),
-        )));
+        ))));
 
         $this->assertTrue($repo->contains('/webmozart/'));
     }
 
     public function testContainsInterpretsConsecutiveSlashesAsRoot()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $this->assertTrue($repo->contains('///'));
     }
@@ -168,9 +180,9 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testContainsExpectsAbsolutePath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart'),
-        )));
+        ))));
 
         $repo->contains('webmozart');
     }
@@ -180,7 +192,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testContainsExpectsNonEmptyPath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->contains('');
     }
@@ -190,18 +202,18 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testContainsExpectsStringPath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->contains(new \stdClass());
     }
 
     public function testGetResource()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli'),
+                $this->createDirectory('/puli'),
             )),
-        )));
+        ))));
 
         $resource = $repo->get('/webmozart');
 
@@ -213,13 +225,13 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testGetBodyResource()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/file'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/file'),
                 )),
             )),
-        )));
+        ))));
 
         $resource = $repo->get('/webmozart/puli/file');
 
@@ -231,42 +243,42 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testGetDiscardsTrailingSlash()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart'),
-        )));
+        ))));
 
         $this->assertEquals($repo->get('/webmozart'), $repo->get('/webmozart/'));
     }
 
     public function testGetInterpretsConsecutiveSlashesAsRoot()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $this->assertEquals($repo->get('/'), $repo->get('///'));
     }
 
     public function testGetCanonicalizesFilePaths()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/file'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/file'),
                 )),
             )),
-        )));
+        ))));
 
         $this->assertEquals($repo->get('/webmozart/puli/file'), $repo->get('/webmozart/puli/../puli/./file'));
     }
 
     public function testGetCanonicalizesDirectoryPaths()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createDirectory('/webmozart/puli/dir'),
+                $this->createDirectory('/puli', array(
+                    $this->createDirectory('/dir'),
                 )),
             )),
-        )));
+        ))));
 
         $this->assertEquals($repo->get('/webmozart/puli/dir'), $repo->get('/webmozart/puli/../puli/dir'));
     }
@@ -276,7 +288,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testGetExpectsExistingResource()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->get('/foo/bar');
     }
@@ -286,9 +298,9 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testGetExpectsAbsolutePath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart'),
-        )));
+        ))));
 
         $repo->get('webmozart');
     }
@@ -298,7 +310,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testGetExpectsNonEmptyPath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->get('');
     }
@@ -308,29 +320,29 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testGetExpectsStringPath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->get(new \stdClass());
     }
 
     public function testGetDotInDirectory()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart'),
-        )));
+        ))));
 
         $this->assertEquals($repo->get('/webmozart'), $repo->get('/webmozart/.'));
     }
 
     public function testGetDotInFile()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/file1'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/file1'),
                 )),
             )),
-        )));
+        ))));
 
         // We support this case even though it leads to an error if done
         // on a regular file system, because recognizing files would be too
@@ -341,31 +353,31 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testGetDotInRoot()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $this->assertEquals($repo->get('/'), $repo->get('/.'));
     }
 
     public function testGetDotDotInDirectory()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli'),
+                $this->createDirectory('/puli'),
             )),
-        )));
+        ))));
 
         $this->assertEquals($repo->get('/webmozart'), $repo->get('/webmozart/puli/..'));
     }
 
     public function testGetDotDotInFile()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/file'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/file'),
                 )),
             )),
-        )));
+        ))));
 
         // We support this case even though it leads to an error if done
         // on a regular file system, because recognizing files would be too
@@ -376,23 +388,23 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testGetDotDotInRoot()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $this->assertEquals($repo->get('/'), $repo->get('/..'));
     }
 
     public function testHasChildren()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/.dotfile'),
-                    $this->createFile('/webmozart/puli/foo'),
-                    $this->createFile('/webmozart/puli/bar'),
-                    $this->createDirectory('/webmozart/puli/dir'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/.dotfile'),
+                    $this->createFile('/foo'),
+                    $this->createFile('/bar'),
+                    $this->createDirectory('/dir'),
                 )),
             )),
-        )));
+        ))));
 
         $this->assertTrue($repo->hasChildren('/'));
         $this->assertTrue($repo->hasChildren('/webmozart'));
@@ -408,7 +420,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testHasChildrenExpectsExistingResource()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->hasChildren('/foo/bar');
     }
@@ -418,9 +430,9 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testHasChildrenExpectsAbsolutePath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart'),
-        )));
+        ))));
 
         $repo->hasChildren('webmozart');
     }
@@ -430,7 +442,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testHasChildrenExpectsNonEmptyPath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->hasChildren('');
     }
@@ -440,31 +452,31 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testHasChildrenExpectsStringPath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->hasChildren(new \stdClass());
     }
 
     public function testListChildren()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/.dotfile'),
-                    $this->createFile('/webmozart/puli/foo'),
-                    $this->createFile('/webmozart/puli/bar'),
-                    $this->createDirectory('/webmozart/puli/dir', array(
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/.dotfile'),
+                    $this->createFile('/foo'),
+                    $this->createFile('/bar'),
+                    $this->createDirectory('/dir', array(
                         // Nest another directory which matches the regex
                         // /webmozart/puli/[^/]+$
-                        $this->createDirectory('/webmozart/puli/dir/webmozart', array(
-                            $this->createDirectory('/webmozart/puli/dir/webmozart/puli', array(
-                                $this->createFile('/webmozart/puli/dir/webmozart/puli/file'),
-                            )),
+                        $this->createDirectory('/webmozart', array(
+                            $this->createDirectory('/puli', array(
+                                $this->createFile('/file'),
+                            ))
                         )),
                     )),
                 )),
             )),
-        )));
+        ))));
 
         $resources = $repo->listChildren('/webmozart/puli');
 
@@ -479,13 +491,13 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testListChildrenReturnsEmptyCollectionForFiles()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/foo'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/foo'),
                 )),
             )),
-        )));
+        ))));
 
         $resources = $repo->listChildren('/webmozart/puli/foo');
 
@@ -495,10 +507,10 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testListRoot()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart'),
             $this->createDirectory('/acme'),
-        )));
+        ))));
 
         $resources = $repo->listChildren('/');
 
@@ -514,7 +526,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testListChildrenExpectsExistingResource()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->listChildren('/foo/bar');
     }
@@ -524,9 +536,9 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testListChildrenExpectsAbsolutePath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart'),
-        )));
+        ))));
 
         $repo->listChildren('webmozart');
     }
@@ -536,7 +548,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testListChildrenExpectsNonEmptyPath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->listChildren('');
     }
@@ -546,23 +558,23 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testListChildrenExpectsStringPath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->listChildren(new \stdClass());
     }
 
     public function testFind()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/.dotfoo'),
-                    $this->createFile('/webmozart/puli/foo'),
-                    $this->createFile('/webmozart/puli/bar'),
-                    $this->createDirectory('/webmozart/puli/dirfoo'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/.dotfoo'),
+                    $this->createFile('/foo'),
+                    $this->createFile('/bar'),
+                    $this->createDirectory('/dirfoo'),
                 )),
             )),
-        )));
+        ))));
 
         $resources = $repo->find('/webmozart/**/*foo');
 
@@ -576,16 +588,16 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testFindBrackets()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/.dotfoo'),
-                    $this->createFile('/webmozart/puli/foo'),
-                    $this->createFile('/webmozart/puli/bar'),
-                    $this->createDirectory('/webmozart/puli/dirfoo'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/.dotfoo'),
+                    $this->createFile('/foo'),
+                    $this->createFile('/bar'),
+                    $this->createDirectory('/dirfoo'),
                 )),
             )),
-        )));
+        ))));
 
         $resources = $repo->find('/webmozart/puli/{foo,bar}');
 
@@ -598,16 +610,16 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testFindFull()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/.dotfoo'),
-                    $this->createFile('/webmozart/puli/foo'),
-                    $this->createFile('/webmozart/puli/bar'),
-                    $this->createDirectory('/webmozart/puli/dirfoo'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/.dotfoo'),
+                    $this->createFile('/foo'),
+                    $this->createFile('/bar'),
+                    $this->createDirectory('/dirfoo'),
                 )),
             )),
-        )));
+        ))));
 
         $resources = $repo->find('/webmozart/**/*{foo,bar}');
 
@@ -622,13 +634,13 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testFindFile()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/file'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/file'),
                 )),
             )),
-        )));
+        ))));
 
         $resources = $repo->find('/webmozart/puli/file');
 
@@ -639,9 +651,9 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testFindDirectory()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart'),
-        )));
+        ))));
 
         $resources = $repo->find('/webmozart');
 
@@ -652,13 +664,13 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testFindCanonicalizesGlob()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/', array(
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/', array(
             $this->createDirectory('/webmozart', array(
-                $this->createDirectory('/webmozart/puli', array(
-                    $this->createFile('/webmozart/puli/file1'),
+                $this->createDirectory('/puli', array(
+                    $this->createFile('/file1'),
                 )),
             )),
-        )));
+        ))));
 
         $resources = $repo->find('/webmozart/puli/../puli/./**');
 
@@ -669,7 +681,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testFindNoMatches()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $resources = $repo->find('/foo/**');
 
@@ -682,7 +694,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testFindExpectsAbsolutePath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->find('*');
     }
@@ -692,7 +704,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testFindExpectsNonEmptyPath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->find('');
     }
@@ -702,7 +714,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
      */
     public function testFindExpectsStringPath()
     {
-        $repo = $this->createPrefilledRepository($this->createDirectory('/'));
+        $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));
 
         $repo->find(new \stdClass());
     }

--- a/tests/AbstractRepositoryTest.php
+++ b/tests/AbstractRepositoryTest.php
@@ -52,7 +52,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Build the real backend structure
+     * Build the real backend structure.
      *
      * @param Resource $root
      *
@@ -471,7 +471,7 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
                         $this->createDirectory('/webmozart', array(
                             $this->createDirectory('/puli', array(
                                 $this->createFile('/file'),
-                            ))
+                            )),
                         )),
                     )),
                 )),

--- a/tests/PathMappingRepositoryTest.php
+++ b/tests/PathMappingRepositoryTest.php
@@ -1,0 +1,389 @@
+<?php
+
+/*
+ * This file is part of the puli/repository package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Puli\Repository\Tests;
+
+use Puli\Repository\Api\EditableRepository;
+use Puli\Repository\Api\Resource\Resource;
+use Puli\Repository\PathMappingRepository;
+use Puli\Repository\Resource\DirectoryResource;
+use Puli\Repository\Resource\FileResource;
+use Puli\Repository\Tests\Resource\TestFilesystemDirectory;
+use Puli\Repository\Tests\Resource\TestFilesystemFile;
+use Symfony\Component\Filesystem\Filesystem;
+use Webmozart\KeyValueStore\ArrayStore;
+
+/**
+ * @since  1.0
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class PathMappingRepositoryTest extends AbstractEditableRepositoryTest
+{
+    /**
+     * @var ArrayStore
+     */
+    protected $store;
+
+    /**
+     * @var PathMappingRepository
+     */
+    protected $repo;
+
+    /**
+     * Temporary directory for test filess
+     *
+     * @var string
+     */
+    protected $tempDir;
+
+    /**
+     * Counter to avoid collisions during tests on directories
+     *
+     * @var int
+     */
+    protected static $createdDirectories = 0;
+
+    /**
+     * Counter to avoid collisions during tests on files
+     *
+     * @var int
+     */
+    protected static $createdFiles = 0;
+
+
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->tempDir = sys_get_temp_dir() . '/puli-repository/PathMappingRepositoryTest' . md5(uniqid(time(), true));
+        $this->tempDir = __DIR__ . '/../../fixtures/tests';
+        mkdir($this->tempDir, 0777, true);
+
+        $this->store = new ArrayStore();
+        $this->repo = new PathMappingRepository($this->store);
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $filesystem = new Filesystem();
+        $filesystem->remove($this->tempDir);
+    }
+
+
+    protected function createPrefilledRepository(Resource $root)
+    {
+        $repo = new PathMappingRepository(new ArrayStore());
+        $repo->add('/', $root);
+
+        return $repo;
+    }
+
+    protected function createWriteRepository()
+    {
+        return new PathMappingRepository(new ArrayStore());
+    }
+
+    protected function createReadRepository(EditableRepository $writeRepo)
+    {
+        return $writeRepo;
+    }
+
+    protected function createFile($path = null, $body = TestFilesystemFile::BODY)
+    {
+        return new TestFilesystemFile($path, $body);
+    }
+
+    protected function createDirectory($path = null, array $children = array())
+    {
+        return new TestFilesystemDirectory($path, $children);
+    }
+
+    protected function buildStructure(Resource $root)
+    {
+        return $this->buildRecursive($root);
+    }
+
+    /**
+     * @param TestFilesystemFile|TestFilesystemDirectory $resource
+     * @param string $parentPath
+     * @return DirectoryResource|FileResource
+     */
+    protected function buildRecursive($resource, $parentPath = '')
+    {
+        if ($resource instanceof TestFilesystemDirectory) {
+            if ($resource->getPath() !== null) {
+                $dirname = rtrim($parentPath . $resource->getPath(), '/');
+            } else {
+                $dirname = $parentPath . '/dir' . self::$createdDirectories;
+                self::$createdDirectories++;
+            }
+
+            if (! is_dir($this->tempDir . $dirname)) {
+                mkdir($this->tempDir . $dirname, 0777, true);
+            }
+
+            foreach ($resource->listChildren() as $child) {
+                $this->buildRecursive($child, $dirname);
+            }
+
+            return new DirectoryResource($this->tempDir . $dirname, $resource->getPath());
+        } else {
+            if ($resource->getPath() !== null) {
+                $filename = rtrim($parentPath . $resource->getPath(), '/');
+            } else {
+                $filename = $parentPath . '/file' . self::$createdFiles;
+                self::$createdFiles++;
+            }
+
+            $dirname = dirname($this->tempDir . $filename);
+
+            if (! is_dir($dirname)) {
+                mkdir($dirname, 0777, true);
+            }
+
+            file_put_contents($this->tempDir . $filename, $resource->getBody());
+
+            return new FileResource($this->tempDir . $filename, $resource->getPath());
+        }
+    }
+
+
+
+    public function testCreateWithFilledStore()
+    {
+        $store = new ArrayStore();
+        $store->set('/webmozart', __DIR__ . '/Fixtures/dir5');
+        $store->set('/webmozart/file1', __DIR__ . '/Fixtures/dir5/file1');
+
+        $repo = new PathMappingRepository($store);
+
+        $this->assertTrue($repo->contains('/webmozart'));
+        $this->assertTrue($repo->contains('/webmozart/file1'));
+    }
+
+    public function testAddDirectoryCompletelyResolveChildren()
+    {
+        $this->writeRepo->add('/webmozart', new DirectoryResource(__DIR__ . '/Fixtures/dir5'));
+
+        $this->assertTrue($this->readRepo->contains('/webmozart'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/file1'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/file2'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/sub'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/sub/file3'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/sub/file4'));
+    }
+
+    public function testAddClonesResourcesAttachedToAnotherRepository()
+    {
+        $otherRepo = $this->getMock('Puli\Repository\Api\ResourceRepository');
+
+        $file = $this->buildStructure($this->createFile('/webmozart/file'));
+        $file->attachTo($otherRepo);
+
+        $this->repo->add('/webmozart/file', $file);
+
+        $this->assertNotSame($file, $this->repo->get('/webmozart/file'));
+        $this->assertSame('/webmozart/file', $file->getPath());
+
+        $clone = clone $file;
+        $clone->attachTo($this->repo, '/webmozart/file');
+
+        $this->assertEquals($clone, $this->repo->get('/webmozart/file'));
+    }
+
+    /**
+     * @expectedException \Puli\Repository\Api\UnsupportedLanguageException
+     * @expectedExceptionMessage foobar
+     */
+    public function testContainsFailsIfLanguageNotGlob()
+    {
+        $this->readRepo->contains('/*', 'foobar');
+    }
+
+    /**
+     * @expectedException \Puli\Repository\Api\UnsupportedLanguageException
+     * @expectedExceptionMessage foobar
+     */
+    public function testFindFailsIfLanguageNotGlob()
+    {
+        $this->readRepo->find('/*', 'foobar');
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testRemoveFile()
+    {
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
+
+        $this->assertTrue($this->readRepo->contains('/webmozart'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file2'));
+
+        $this->assertSame(1, $this->writeRepo->remove('/webmozart/puli/file1'));
+
+        $this->assertTrue($this->readRepo->contains('/webmozart'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file2'));
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testRemoveMany()
+    {
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
+
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file2'));
+
+        $this->assertSame(2, $this->writeRepo->remove('/webmozart/puli/file*'));
+
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli/file2'));
+    }
+
+    /**
+     * @dataProvider provideDirectoryGlob
+     * @expectedException \BadMethodCallException
+     */
+    public function testRemoveDirectory($glob)
+    {
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
+
+        $this->assertTrue($this->readRepo->contains('/webmozart'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file2'));
+
+        $this->assertSame(3, $this->writeRepo->remove('/*'));
+
+        $this->assertTrue($this->readRepo->contains('/webmozart'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli/file2'));
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testRemoveDot()
+    {
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
+
+        $this->assertTrue($this->readRepo->contains('/webmozart'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file2'));
+
+        $this->writeRepo->remove('/webmozart/puli/.');
+
+        $this->assertTrue($this->readRepo->contains('/webmozart'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli/file2'));
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testRemoveDotDot()
+    {
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
+
+        $this->assertTrue($this->readRepo->contains('/'));
+        $this->assertTrue($this->readRepo->contains('/webmozart'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file2'));
+
+        $this->writeRepo->remove('/webmozart/puli/..');
+
+        $this->assertTrue($this->readRepo->contains('/'));
+        $this->assertFalse($this->readRepo->contains('/webmozart'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli/file2'));
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testRemoveDiscardsTrailingSlash()
+    {
+        $this->writeRepo->add('/webmozart/puli/file1', $this->buildStructure($this->createFile()));
+        $this->writeRepo->add('/webmozart/puli/file2', $this->buildStructure($this->createFile()));
+
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertTrue($this->readRepo->contains('/webmozart/puli/file2'));
+
+        $this->writeRepo->remove('/webmozart/puli/');
+
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli/file1'));
+        $this->assertFalse($this->readRepo->contains('/webmozart/puli/file2'));
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testCannotRemoveRoot()
+    {
+        $this->writeRepo->remove('/');
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testRemoveInterpretsConsecutiveSlashesAsRoot()
+    {
+        $this->writeRepo->remove('///');
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testRemoveExpectsAbsolutePath()
+    {
+        $this->writeRepo->remove('webmozart');
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testRemoveExpectsNonEmptyPath()
+    {
+        $this->writeRepo->remove('');
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testRemoveExpectsStringPath()
+    {
+        $this->writeRepo->remove(new \stdClass());
+    }
+
+}

--- a/tests/PathMappingRepositoryTest.php
+++ b/tests/PathMappingRepositoryTest.php
@@ -159,7 +159,21 @@ class PathMappingRepositoryTest extends AbstractEditableRepositoryTest
         }
     }
 
+    public function testResolveMultipleBasePath()
+    {
+        $this->writeRepo->add('/webmozart/puli', $this->buildStructure($this->createDirectory('', array(
+            $this->createFile('/file1', 'original 1'),
+        ))));
 
+        $this->writeRepo->add('/webmozart', $this->buildStructure($this->createDirectory('/puli', array(
+            $this->createFile('/file2', 'original 2'),
+        ))));
+
+        $this->assertTrue($this->writeRepo->contains('/webmozart'));
+        $this->assertTrue($this->writeRepo->contains('/webmozart/puli'));
+        $this->assertTrue($this->writeRepo->contains('/webmozart/puli/file1'));
+        $this->assertTrue($this->writeRepo->contains('/webmozart/puli/file2'));
+    }
 
     public function testCreateWithFilledStore()
     {

--- a/tests/PathMappingRepositoryTest.php
+++ b/tests/PathMappingRepositoryTest.php
@@ -65,13 +65,6 @@ class PathMappingRepositoryTest extends AbstractEditableRepositoryTest
         parent::setUp();
 
         $this->tempDir = sys_get_temp_dir().'/puli-repository/PathMappingRepositoryTest'.md5(uniqid(time(), true));
-        $this->tempDir = __DIR__.'/../../fixtures/tests';
-
-        if (is_dir($this->tempDir)) {
-            $filesystem = new Filesystem();
-            $filesystem->remove($this->tempDir);
-        }
-
         mkdir($this->tempDir, 0777, true);
 
         $this->store = new ArrayStore();


### PR DESCRIPTION
Following the OptimizedPathMapping repository (puli/repository#27), I implemented a development version of this repository, as proposed by @webmozart in puli/issues#80. This pull-request is a place to debate over the code.

I did three main things:

**1. Create the repository**

https://github.com/tgalopin/repository/blob/dev-path-mapping/src/PathMappingRepository.php

The repository follows these rules:
- When a resource is added, the association `repositoryPath => filesystemPath` is stored in the KeyValueStore, and the parents of the repositoryPath are created as virtual resources ;
-  When a resource is fetched (using `get()` or other methods), its repositoryPath is *resolved* to a filesystemPath: the repository find the list of virtual resources matching the searched resource repositoryPath and try to find a real directory / file corresponding to the resource in each of these virtual resources ;

This technique is much slower than the optimized version (obviously :) ) but it's a really useful tool for development as the structure inside virtual resources can change without having to "recreate" the puli repository.

**2. Add a build structure system in tests**

https://github.com/tgalopin/repository/blob/dev-path-mapping/tests/AbstractRepositoryTest.php#L62

This repository was not possible to test using the exact same tests as before as when we are requesting a resources, it can be either a virtual or a real one, and tests have to check for both at the same time.

I had to create a real valid structure on filesystem according to the tests: I couldn't without altering a bit the existing tests.

I added a `buildStructure` method, called on each built resources (for instance https://github.com/tgalopin/repository/blob/dev-path-mapping/tests/AbstractRepositoryTest.php#L102) that by default return the root resource to be compatible with other repositories tests.

But in the PathMappingRepository tests, this method create the structure (https://github.com/tgalopin/repository/blob/dev-path-mapping/tests/PathMappingRepositoryTest.php#L113) for tests to work properly.

**3. Create the specific tests for the PathMappingRepository**

Once the built structure ready, I fixed the repository to pass the tests (https://github.com/tgalopin/repository/blob/dev-path-mapping/tests/PathMappingRepositoryTest.php).


I'm very open to modifications, expecially on how `find()` and `contains()` work as I'm not sure it's the best algorithm possible.