### PR TITLE
Fix phpdoc type

### DIFF
--- a/src/Api/EditableRepository.php
+++ b/src/Api/EditableRepository.php
@@ -12,6 +12,7 @@
 namespace Puli\Repository\Api;
 
 use InvalidArgumentException;
+use Puli\Repository\Api\Resource\Resource;
 
 /**
  * A repository that supports the addition and removal of resources.

--- a/src/Api/ResourceRepository.php
+++ b/src/Api/ResourceRepository.php
@@ -12,6 +12,7 @@
 namespace Puli\Repository\Api;
 
 use InvalidArgumentException;
+use Puli\Repository\Api\Resource\Resource;
 
 /**
  * Stores {@link Resource} objects.


### PR DESCRIPTION
Was previously using `\Resource` instead of `Puli\Repository\Api\Resource\Resource`.

This is quite confusing when using the `ResourceRepository` as there is no auto-completion after `get()`.

However be aware: when testing locally, it seems PhpStorm has a bug and ignores the `use …`. As a consequence, it still believes the return type to be `\Resource`. I am on the latest EAP so I hope it's just a bug with the EAP.