### PR TITLE
Fix Windows symlink time information

### DIFF
--- a/src/Resource/Metadata/FilesystemMetadata.php
+++ b/src/Resource/Metadata/FilesystemMetadata.php
@@ -17,7 +17,6 @@ use Puli\Repository\Api\Resource\ResourceMetadata;
  * Metadata about a file on the filesystem.
  *
  * @since  1.0
- * 
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class FilesystemMetadata extends ResourceMetadata
@@ -27,23 +26,6 @@ class FilesystemMetadata extends ResourceMetadata
     public function __construct($filesystemPath)
     {
         $this->filesystemPath = $filesystemPath;
-    }
-
-    /**
-     * On Windows, fileXtime functions see only changes
-     * on the symlink file and not the original one.
-     *
-     * @param string $path
-     *
-     * @return string
-     */
-    private function fixWindowsPath($path)
-    {
-        if (is_link($path) && defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            $path = readlink($path);
-        }
-
-        return $path;
     }
 
     /**
@@ -94,5 +76,22 @@ class FilesystemMetadata extends ResourceMetadata
         clearstatcache(true, $path);
 
         return filesize($path);
+    }
+
+    /**
+     * On Windows, fileXtime functions see only changes
+     * on the symlink file and not the original one.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    private function fixWindowsPath($path)
+    {
+        if (is_link($path) && defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            $path = readlink($path);
+        }
+
+        return $path;
     }
 }

--- a/src/Resource/Metadata/FilesystemMetadata.php
+++ b/src/Resource/Metadata/FilesystemMetadata.php
@@ -17,7 +17,7 @@ use Puli\Repository\Api\Resource\ResourceMetadata;
  * Metadata about a file on the filesystem.
  *
  * @since  1.0
- *
+ * 
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class FilesystemMetadata extends ResourceMetadata
@@ -30,14 +30,32 @@ class FilesystemMetadata extends ResourceMetadata
     }
 
     /**
+     * On Windows, fileXtime functions see only changes
+     * on the symlink file and not the original one.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    private function fixWindowsPath($path)
+    {
+        if (is_link($path) && defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            $path = readlink($path);
+        }
+
+        return $path;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getCreationTime()
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            clearstatcache(true, $this->filesystemPath);
+            $path = $this->fixWindowsPath($this->filesystemPath);
+            clearstatcache(true, $path);
 
-            return filectime($this->filesystemPath);
+            return filectime($path);
         }
 
         // On Unix, filectime() returns the change time of the inode, not the
@@ -50,9 +68,10 @@ class FilesystemMetadata extends ResourceMetadata
      */
     public function getAccessTime()
     {
-        clearstatcache(true, $this->filesystemPath);
+        $path = $this->fixWindowsPath($this->filesystemPath);
+        clearstatcache(true, $path);
 
-        return fileatime($this->filesystemPath);
+        return fileatime($path);
     }
 
     /**
@@ -60,9 +79,10 @@ class FilesystemMetadata extends ResourceMetadata
      */
     public function getModificationTime()
     {
-        clearstatcache(true, $this->filesystemPath);
+        $path = $this->fixWindowsPath($this->filesystemPath);
+        clearstatcache(true, $path);
 
-        return filemtime($this->filesystemPath);
+        return filemtime($path);
     }
 
     /**
@@ -70,8 +90,9 @@ class FilesystemMetadata extends ResourceMetadata
      */
     public function getSize()
     {
-        clearstatcache(true, $this->filesystemPath);
+        $path = $this->fixWindowsPath($this->filesystemPath);
+        clearstatcache(true, $path);
 
-        return filesize($this->filesystemPath);
+        return filesize($path);
     }
 }


### PR DESCRIPTION
On Windows, symlink does not work like on Unix, the OS think it is a real file like another. So for time operations, it only see changes on the symlink file and not the original one. That mean fileXtime functions get info about the symlink file too.

So if you make some changes in the original file, Puli will not seen anything if this file is register in the repository as a symlink. It work as espected for files in a symlink directory.