### PR TITLE
* failing test to show problem with resolving childrens file systempaths

### DIFF
--- a/src/PathMappingRepository.php
+++ b/src/PathMappingRepository.php
@@ -224,6 +224,7 @@ class PathMappingRepository extends AbstractPathMappingRepository implements Edi
 
             foreach ($filesystemBasePaths as $filesystemBasePath) {
                 $filesystemPath = substr_replace($path, rtrim($filesystemBasePath, '/').'/', 0, strlen($basePath));
+                $filesystemPath = str_replace('//', '/', $filesystemPath);
 
                 if (file_exists($filesystemPath)) {
                     $filesystemPaths[] = $filesystemPath;

--- a/src/Resource/GenericResource.php
+++ b/src/Resource/GenericResource.php
@@ -67,6 +67,7 @@ class GenericResource implements Resource
     {
         return $this->path ? basename($this->path) : null;
     }
+
     /**
      * {@inheritdoc}
      */

--- a/src/StreamWrapper/StreamWrapper.php
+++ b/src/StreamWrapper/StreamWrapper.php
@@ -23,27 +23,44 @@ namespace Puli\Repository\StreamWrapper;
 interface StreamWrapper
 {
     public function dir_closedir();
+
     public function dir_opendir($url, $options);
+
     public function dir_readdir();
+
     public function dir_rewinddir();
 
     public function mkdir($url, $mode, $options);
+
     public function rename($urlFrom, $urlTo);
+
     public function rmdir($url, $options);
 
     public function stream_cast($castAs);
+
     public function stream_close();
+
     public function stream_eof();
+
     public function stream_flush();
+
     public function stream_lock($operation);
+
     public function stream_open($url, $mode, $options, &$openedPath);
+
     public function stream_read($length);
+
     public function stream_seek($offset, $whence = SEEK_SET);
+
     public function stream_set_option($option, $arg1, $arg2);
+
     public function stream_stat();
+
     public function stream_tell();
+
     public function stream_write($data);
 
     public function unlink($url);
+
     public function url_stat($url, $flags);
 }

--- a/tests/PathMappingRepositoryTest.php
+++ b/tests/PathMappingRepositoryTest.php
@@ -283,6 +283,19 @@ class PathMappingRepositoryTest extends AbstractEditableRepositoryTest
         $this->assertEquals($clone, $this->repo->get('/webmozart/file'));
     }
 
+    public function testResolveChildrenWithCorrectFileSystemPaths()
+    {
+        $root = $this->buildStructure($this->createDirectory('', array(
+            $this->createDirectory('/sub2', array(
+                $this->createFile('/file2', 'original 2'),
+            )),
+        )));
+
+        $this->writeRepo->add('/webmozart', new DirectoryResource($root->getFilesystemPath()));
+
+        $this->assertCount(1, $this->writeRepo->find('/webmozart/sub2/*')->toArray());
+    }
+
     /**
      * @expectedException \Puli\Repository\Api\UnsupportedLanguageException
      * @expectedExceptionMessage foobar


### PR DESCRIPTION
This PR shows a problem with resolving children filesystempaths.

```php
PathMappingRepository.php Line 226
$filesystemPath = substr_replace($path, rtrim($filesystemBasePath, '/').'/', 0, strlen($basePath));
```

If you use find to resolve the children, the filesystemPath contains after this line potential '//' in the path and this doesn't match than in the "getFilesystemPathChildren" method and so no correct repository path is set.

Potential Bugfix is to replace all '//' with '/' in the filesystemPath