### PR TITLE
Slashes issue in file resources in PathMappingRepository

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -11,3 +11,6 @@ disabled:
     # Unusable at the moment
     # https://github.com/StyleCI/StyleCI/issues/471
     - psr0
+
+    # To avoid Resource / resource confusion
+    - phpdoc_types

--- a/src/Api/ResourceCollection.php
+++ b/src/Api/ResourceCollection.php
@@ -77,7 +77,7 @@ interface ResourceCollection extends Traversable, ArrayAccess, Countable
     /**
      * Returns the keys of the collection.
      *
-     * @return integer[] The collection keys.
+     * @return int[] The collection keys.
      */
     public function keys();
 

--- a/src/PathMappingRepository.php
+++ b/src/PathMappingRepository.php
@@ -221,9 +221,11 @@ class PathMappingRepository extends AbstractPathMappingRepository implements Edi
             }
 
             $filesystemBasePaths = (array) $this->store->get($basePath);
+            $basePathLength = strlen(rtrim($basePath, '/').'/');
 
             foreach ($filesystemBasePaths as $filesystemBasePath) {
-                $filesystemPath = substr_replace($path, rtrim($filesystemBasePath, '/').'/', 0, strlen($basePath));
+                $filesystemBasePath = rtrim($filesystemBasePath, '/').'/';
+                $filesystemPath = substr_replace($path, $filesystemBasePath, 0, $basePathLength);
 
                 if (file_exists($filesystemPath)) {
                     $filesystemPaths[] = $filesystemPath;

--- a/tests/PathMappingRepositoryTest.php
+++ b/tests/PathMappingRepositoryTest.php
@@ -208,6 +208,28 @@ class PathMappingRepositoryTest extends AbstractEditableRepositoryTest
         $this->assertCount(2, $bar->getChild('/sub')->listChildren()->toArray());
     }
 
+    public function testResolveFilesystemResource()
+    {
+        $store = new ArrayStore();
+        $store->set('/', null);
+        $store->set('/webmozart', null);
+        $store->set('/webmozart/foo', array(__DIR__.'/Fixtures/dir5'));
+
+        $repository = new PathMappingRepository($store);
+
+        // Get
+        $resource = $repository->get('/webmozart/foo/sub');
+
+        $this->assertInstanceOf('Puli\Repository\Api\Resource\FilesystemResource', $resource);
+        $this->assertEquals(__DIR__.'/Fixtures/dir5/sub', $resource->getFilesystemPath());
+
+        // Find
+        $resource = $repository->find('/**/sub')->get(0);
+
+        $this->assertInstanceOf('Puli\Repository\Api\Resource\FilesystemResource', $resource);
+        $this->assertEquals(__DIR__.'/Fixtures/dir5/sub', $resource->getFilesystemPath());
+    }
+
     public function testListVirtualResourceChildren()
     {
         $this->writeRepo->add('/webmozart', new DirectoryResource(__DIR__.'/Fixtures/dir5'));


### PR DESCRIPTION
Fix issue with slashes in prefilled PathMapping repositories.

Fix puli/issues#113 and #48.