### PR TITLE
Fix tests on Windows

### DIFF
--- a/tests/PathMappingRepositoryTest.php
+++ b/tests/PathMappingRepositoryTest.php
@@ -221,13 +221,13 @@ class PathMappingRepositoryTest extends AbstractEditableRepositoryTest
         $resource = $repository->get('/webmozart/foo/sub');
 
         $this->assertInstanceOf('Puli\Repository\Api\Resource\FilesystemResource', $resource);
-        $this->assertEquals(__DIR__.'/Fixtures/dir5/sub', $resource->getFilesystemPath());
+        $this->assertEquals(str_replace(__DIR__, DIRECTORY_SEPARATOR, '/').'/Fixtures/dir5/sub', $resource->getFilesystemPath());
 
         // Find
         $resource = $repository->find('/**/sub')->get(0);
 
         $this->assertInstanceOf('Puli\Repository\Api\Resource\FilesystemResource', $resource);
-        $this->assertEquals(__DIR__.'/Fixtures/dir5/sub', $resource->getFilesystemPath());
+        $this->assertEquals(str_replace(__DIR__, DIRECTORY_SEPARATOR, '/').'/Fixtures/dir5/sub', $resource->getFilesystemPath());
     }
 
     public function testListVirtualResourceChildren()


### PR DESCRIPTION
The repository always return paths using ``/`` as directory separator, so the expectation needs to normalize ``__DIR__`` too.