### PR TITLE
Allow running symlink-based tests on supported Windows environments

### DIFF
--- a/tests/FilesystemRepositoryAbsoluteSymlinkTest.php
+++ b/tests/FilesystemRepositoryAbsoluteSymlinkTest.php
@@ -36,9 +36,7 @@ class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractFilesystemReposito
 
     protected function setUp()
     {
-        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            $this->markTestSkipped('Symbolic links are not supported on some Windows enviroments.');
-        }
+        $this->markAsSkippedIfSymlinkIsMissing();
 
         $this->tempBaseDir = TestUtil::makeTempDir('puli-repository', __CLASS__);
 

--- a/tests/FilesystemRepositoryCopyTest.php
+++ b/tests/FilesystemRepositoryCopyTest.php
@@ -79,9 +79,7 @@ class FilesystemRepositoryCopyTest extends AbstractEditableRepositoryTest
 
     public function testGetFileLink()
     {
-        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            $this->markTestSkipped('Symbolic links are not supported on some Windows enviroments.');
-        }
+        $this->markAsSkippedIfSymlinkIsMissing();
 
         touch($this->tempDir.'/file');
         symlink($this->tempDir.'/file', $this->tempDir.'/link');
@@ -94,9 +92,7 @@ class FilesystemRepositoryCopyTest extends AbstractEditableRepositoryTest
 
     public function testGetDirectoryLink()
     {
-        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            $this->markTestSkipped('Symbolic links are not supported on some Windows enviroments.');
-        }
+        $this->markAsSkippedIfSymlinkIsMissing();
 
         mkdir($this->tempDir.'/dir');
         symlink($this->tempDir.'/dir', $this->tempDir.'/link');

--- a/tests/FilesystemRepositoryRelativeSymlinkTest.php
+++ b/tests/FilesystemRepositoryRelativeSymlinkTest.php
@@ -37,7 +37,7 @@ class FilesystemRepositoryRelativeSymlinkTest extends AbstractEditableRepository
     protected function setUp()
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            $this->markTestSkipped('Symbolic links are not supported on some Windows enviroments.');
+            $this->markTestSkipped('Relative symbolic links are not supported on Windows.');
         }
 
         $this->tempBaseDir = TestUtil::makeTempDir('puli-repository', __CLASS__);


### PR DESCRIPTION
The logic to detect the symlink support on Windows is copied from the Symfony Filesystem component testsuite. The original implementation is from @nicolas-grekas.