### PR TITLE
[WIP] Store relative paths in path mapping repositories

### DIFF
--- a/src/AbstractPathMappingRepository.php
+++ b/src/AbstractPathMappingRepository.php
@@ -43,13 +43,20 @@ abstract class AbstractPathMappingRepository extends AbstractRepository
     protected $store;
 
     /**
+     * @var string
+     */
+    protected $baseDirectory;
+
+    /**
      * Creates a new repository.
      *
-     * @param KeyValueStore $store The store of all the paths.
+     * @param KeyValueStore $store
+     * @param string        $baseDirectory The store of all the paths.
      */
-    public function __construct(KeyValueStore $store)
+    public function __construct(KeyValueStore $store, $baseDirectory)
     {
         $this->store = $store;
+        $this->baseDirectory = $baseDirectory;
 
         $this->createRoot();
     }
@@ -101,6 +108,16 @@ abstract class AbstractPathMappingRepository extends AbstractRepository
         if ($resource instanceof LinkResource) {
             $this->addLinkResource($path, $resource);
         } else {
+            // Check resource is in base directory
+            if (!Path::isBasePath($this->baseDirectory, $resource->getFilesystemPath())) {
+                throw new UnsupportedResourceException(sprintf(
+                    'This path-mapping repository is based on directory "%s" and '.
+                    'therefore does not support filesystem resource "%s"',
+                    $this->baseDirectory,
+                    $resource->getFilesystemPath()
+                ));
+            }
+
             $this->addFilesystemResource($path, $resource);
         }
     }
@@ -201,12 +218,18 @@ abstract class AbstractPathMappingRepository extends AbstractRepository
      */
     protected function createResource($filesystemPath, $path = null)
     {
+        // Link resource
         if (0 === strpos($filesystemPath, 'l:')) {
             return $this->createLinkResource(substr($filesystemPath, 2), $path);
         }
 
-        if ($filesystemPath && file_exists($filesystemPath)) {
-            return $this->createFilesystemResource($filesystemPath, $path);
+        // Filesystem resource
+        if (is_string($filesystemPath)) {
+            $filesystemPath = $this->makePathAbsolute($filesystemPath);
+
+            if (file_exists($filesystemPath)) {
+                return $this->createFilesystemResource($filesystemPath, $path);
+            }
         }
 
         return $this->createVirtualResource($path);
@@ -277,5 +300,50 @@ abstract class AbstractPathMappingRepository extends AbstractRepository
         $resource->attachTo($this, $path);
 
         return $resource;
+    }
+
+    /**
+     * Transform a relative path into an absolute path.
+     *
+     * @param string $absolutePath
+     *
+     * @return string
+     */
+    protected function makePathRelative($absolutePath)
+    {
+        return Path::makeRelative($absolutePath, $this->baseDirectory);
+    }
+
+    /**
+     * Transform a relative path into an absolute path.
+     *
+     * @param string $relativePath
+     *
+     * @return string
+     */
+    protected function makePathAbsolute($relativePath)
+    {
+        if (0 === strpos($relativePath, 'l:')) {
+            // Link
+            return $relativePath;
+        }
+
+        return Path::makeAbsolute($relativePath, $this->baseDirectory);
+    }
+
+    /**
+     * Transform a collection of relative paths into a collection of absolute paths.
+     *
+     * @param array $relativePaths
+     *
+     * @return array
+     */
+    protected function makePathsAbsolute($relativePaths)
+    {
+        foreach ($relativePaths as $key => $relativePath) {
+            $relativePaths[$key] = $this->makePathAbsolute($relativePath);
+        }
+
+        return $relativePaths;
     }
 }

--- a/src/OptimizedPathMappingRepository.php
+++ b/src/OptimizedPathMappingRepository.php
@@ -24,6 +24,7 @@ use Webmozart\Assert\Assert;
 use Webmozart\Glob\Glob;
 use Webmozart\Glob\Iterator\GlobFilterIterator;
 use Webmozart\Glob\Iterator\RegexFilterIterator;
+use Webmozart\PathUtil\Path;
 
 /**
  * An optimized path mapping resource repository.
@@ -168,7 +169,7 @@ class OptimizedPathMappingRepository extends AbstractPathMappingRepository imple
         $resource->attachTo($this, $path);
 
         // Add the resource before adding its children, so that the array stays sorted
-        $this->store->set($path, $resource->getFilesystemPath());
+        $this->store->set($path, $this->makePathRelative($resource->getFilesystemPath()));
 
         $basePath = '/' === $path ? $path : $path.'/';
 

--- a/src/OptimizedPathMappingRepository.php
+++ b/src/OptimizedPathMappingRepository.php
@@ -169,7 +169,7 @@ class OptimizedPathMappingRepository extends AbstractPathMappingRepository imple
         $resource->attachTo($this, $path);
 
         // Add the resource before adding its children, so that the array stays sorted
-        $this->store->set($path, $this->makePathRelative($resource->getFilesystemPath()));
+        $this->store->set($path, Path::makeRelative($resource->getFilesystemPath(), $this->baseDirectory));
 
         $basePath = '/' === $path ? $path : $path.'/';
 

--- a/src/PathMappingRepository.php
+++ b/src/PathMappingRepository.php
@@ -214,10 +214,10 @@ class PathMappingRepository extends AbstractPathMappingRepository implements Edi
 
             if (is_array($filesystemPaths) && count($filesystemPaths) > 0) {
                 if ($onlyFirst) {
-                    return $this->makePathsAbsolute(array(reset($filesystemPaths)));
+                    return $this->resolveRelativePaths(array(reset($filesystemPaths)));
                 }
 
-                return $this->makePathsAbsolute($filesystemPaths);
+                return $this->resolveRelativePaths($filesystemPaths);
             }
 
             return array(null);
@@ -239,7 +239,7 @@ class PathMappingRepository extends AbstractPathMappingRepository implements Edi
                 continue;
             }
 
-            $filesystemBasePaths = $this->makePathsAbsolute((array) $this->store->get($basePath));
+            $filesystemBasePaths = $this->resolveRelativePaths((array) $this->store->get($basePath));
             $basePathLength = strlen(rtrim($basePath, '/').'/');
 
             foreach ($filesystemBasePaths as $filesystemBasePath) {
@@ -251,13 +251,13 @@ class PathMappingRepository extends AbstractPathMappingRepository implements Edi
                     $filesystemPaths[] = $filesystemPath;
 
                     if ($onlyFirst) {
-                        return $this->makePathsAbsolute($filesystemPaths);
+                        return $this->resolveRelativePaths($filesystemPaths);
                     }
                 }
             }
         }
 
-        return $this->makePathsAbsolute($filesystemPaths);
+        return $this->resolveRelativePaths($filesystemPaths);
     }
 
     /**
@@ -488,7 +488,7 @@ class PathMappingRepository extends AbstractPathMappingRepository implements Edi
             }
 
             foreach ($filesystemPaths as $filesystemPath) {
-                $children[] = array('path' => $path, 'filesystemPath' => $this->makePathAbsolute($filesystemPath));
+                $children[] = array('path' => $path, 'filesystemPath' => $this->resolveRelativePath($filesystemPath));
             }
         }
 

--- a/tests/AbstractPathMappingRepositoryTest.php
+++ b/tests/AbstractPathMappingRepositoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the puli/repository package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Puli\Repository\Tests;
+
+use Puli\Repository\OptimizedPathMappingRepository;
+use Puli\Repository\PathMappingRepository;
+use Symfony\Component\Filesystem\Filesystem;
+use Webmozart\KeyValueStore\Api\KeyValueStore;
+use Webmozart\KeyValueStore\ArrayStore;
+
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+abstract class AbstractPathMappingRepositoryTest extends AbstractEditableRepositoryTest
+{
+    /**
+     * @var ArrayStore
+     */
+    protected $store;
+
+    /**
+     * @var OptimizedPathMappingRepository
+     */
+    protected $repo;
+
+    /**
+     * Temporary directory for test filess.
+     *
+     * @var string
+     */
+    protected $tempDir;
+
+    /**
+     * Counter to avoid collisions during tests on files.
+     *
+     * @var int
+     */
+    protected static $createdFiles = 0;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->tempDir = __DIR__.'/Fixtures/tmp';
+
+        $filesystem = new Filesystem();
+        $filesystem->mkdir($this->tempDir);
+
+        $this->store = new ArrayStore();
+        $this->repo = $this->createBaseDirectoryRepository($this->store, __DIR__.'/Fixtures');
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $filesystem = new Filesystem();
+        $filesystem->remove($this->tempDir);
+    }
+
+    /**
+     * @param KeyValueStore $store
+     * @param string $baseDirectory
+     *
+     * @return PathMappingRepository|OptimizedPathMappingRepository
+     */
+    abstract protected function createBaseDirectoryRepository(KeyValueStore $store, $baseDirectory);
+}

--- a/tests/AbstractPathMappingRepositoryTest.php
+++ b/tests/AbstractPathMappingRepositoryTest.php
@@ -13,6 +13,7 @@ namespace Puli\Repository\Tests;
 
 use Puli\Repository\OptimizedPathMappingRepository;
 use Puli\Repository\PathMappingRepository;
+use Puli\Repository\Resource\FileResource;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\KeyValueStore\Api\KeyValueStore;
 use Webmozart\KeyValueStore\ArrayStore;
@@ -70,9 +71,18 @@ abstract class AbstractPathMappingRepositoryTest extends AbstractEditableReposit
 
     /**
      * @param KeyValueStore $store
-     * @param string $baseDirectory
+     * @param string        $baseDirectory
      *
      * @return PathMappingRepository|OptimizedPathMappingRepository
      */
     abstract protected function createBaseDirectoryRepository(KeyValueStore $store, $baseDirectory);
+
+    /**
+     * @expectedException \Puli\Repository\Api\UnsupportedResourceException
+     */
+    public function testBaseDirectoryException()
+    {
+        $repository = $this->createBaseDirectoryRepository($this->store, __DIR__.'/Fixtures/dir1');
+        $repository->add('/webmozart/foo/bar', new FileResource(__DIR__.'/Fixtures/dir2/file2'));
+    }
 }

--- a/tests/AbstractPathMappingRepositoryTest.php
+++ b/tests/AbstractPathMappingRepositoryTest.php
@@ -11,9 +11,13 @@
 
 namespace Puli\Repository\Tests;
 
+use Puli\Repository\Api\Resource\Resource;
 use Puli\Repository\OptimizedPathMappingRepository;
 use Puli\Repository\PathMappingRepository;
+use Puli\Repository\Resource\DirectoryResource;
 use Puli\Repository\Resource\FileResource;
+use Puli\Repository\Tests\Resource\TestFilesystemDirectory;
+use Puli\Repository\Tests\Resource\TestFilesystemFile;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\KeyValueStore\Api\KeyValueStore;
 use Webmozart\KeyValueStore\ArrayStore;
@@ -48,6 +52,13 @@ abstract class AbstractPathMappingRepositoryTest extends AbstractEditableReposit
      */
     protected static $createdFiles = 0;
 
+    /**
+     * Counter to avoid collisions during tests on directories.
+     *
+     * @var int
+     */
+    protected static $createdDirectories = 0;
+
     protected function setUp()
     {
         parent::setUp();
@@ -67,6 +78,66 @@ abstract class AbstractPathMappingRepositoryTest extends AbstractEditableReposit
 
         $filesystem = new Filesystem();
         $filesystem->remove($this->tempDir);
+    }
+
+    protected function createFile($path = null, $body = TestFilesystemFile::BODY)
+    {
+        return new TestFilesystemFile($path, $body);
+    }
+
+    protected function createDirectory($path = null, array $children = array())
+    {
+        return new TestFilesystemDirectory($path, $children);
+    }
+
+    protected function buildStructure(Resource $root)
+    {
+        return $this->buildRecursive($root);
+    }
+
+    /**
+     * @param TestFilesystemFile|TestFilesystemDirectory $resource
+     * @param string                                     $parentPath
+     *
+     * @return DirectoryResource|FileResource
+     */
+    protected function buildRecursive($resource, $parentPath = '')
+    {
+        if ($resource instanceof TestFilesystemDirectory) {
+            if ($resource->getPath() !== null) {
+                $dirname = rtrim($parentPath.$resource->getPath(), '/');
+            } else {
+                $dirname = $parentPath.'/dir'.self::$createdDirectories;
+                ++self::$createdDirectories;
+            }
+
+            if (!is_dir($this->tempDir.$dirname)) {
+                mkdir($this->tempDir.$dirname, 0777, true);
+            }
+
+            foreach ($resource->listChildren() as $child) {
+                $this->buildRecursive($child, $dirname);
+            }
+
+            return new DirectoryResource($this->tempDir.$dirname, $resource->getPath());
+        } else {
+            if ($resource->getPath() !== null) {
+                $filename = rtrim($parentPath.$resource->getPath(), '/');
+            } else {
+                $filename = $parentPath.'/file'.self::$createdFiles;
+                ++self::$createdFiles;
+            }
+
+            $dirname = dirname($this->tempDir.$filename);
+
+            if (!is_dir($dirname)) {
+                mkdir($dirname, 0777, true);
+            }
+
+            file_put_contents($this->tempDir.$filename, $resource->getBody());
+
+            return new FileResource($this->tempDir.$filename, $resource->getPath());
+        }
     }
 
     /**

--- a/tests/AbstractRepositoryTest.php
+++ b/tests/AbstractRepositoryTest.php
@@ -68,6 +68,14 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(true);
     }
 
+    protected function assertPathsEquals($expected, $actual)
+    {
+        $this->assertEquals(
+            str_replace(DIRECTORY_SEPARATOR, '/', $expected),
+            str_replace(DIRECTORY_SEPARATOR, '/', $actual)
+        );
+    }
+
     public function testContainsPath()
     {
         $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));

--- a/tests/AbstractRepositoryTest.php
+++ b/tests/AbstractRepositoryTest.php
@@ -68,14 +68,6 @@ abstract class AbstractRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(true);
     }
 
-    protected function assertPathsEquals($expected, $actual)
-    {
-        $this->assertEquals(
-            str_replace(DIRECTORY_SEPARATOR, '/', $expected),
-            str_replace(DIRECTORY_SEPARATOR, '/', $actual)
-        );
-    }
-
     public function testContainsPath()
     {
         $repo = $this->createPrefilledRepository($this->buildStructure($this->createDirectory('/')));

--- a/tests/OptimizedPathMappingRepositoryTest.php
+++ b/tests/OptimizedPathMappingRepositoryTest.php
@@ -20,53 +20,18 @@ use Puli\Repository\Tests\Resource\TestFilesystemDirectory;
 use Puli\Repository\Tests\Resource\TestFilesystemFile;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\Glob\Test\TestUtil;
+use Webmozart\KeyValueStore\Api\KeyValueStore;
 use Webmozart\KeyValueStore\ArrayStore;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-class OptimizedPathMappingRepositoryTest extends AbstractEditableRepositoryTest
+class OptimizedPathMappingRepositoryTest extends AbstractPathMappingRepositoryTest
 {
-    /**
-     * @var ArrayStore
-     */
-    protected $store;
-
-    /**
-     * @var OptimizedPathMappingRepository
-     */
-    protected $repo;
-
-    /**
-     * Temporary directory for test filess.
-     *
-     * @var string
-     */
-    protected $tempDir;
-
-    /**
-     * Counter to avoid collisions during tests on files.
-     *
-     * @var int
-     */
-    protected static $createdFiles = 0;
-
-    protected function setUp()
+    protected function createBaseDirectoryRepository(KeyValueStore $store, $baseDirectory)
     {
-        parent::setUp();
-
-        $this->tempDir = TestUtil::makeTempDir('puli-repository', __CLASS__);
-        $this->store = new ArrayStore();
-        $this->repo = new OptimizedPathMappingRepository($this->store);
-    }
-
-    protected function tearDown()
-    {
-        parent::tearDown();
-
-        $filesystem = new Filesystem();
-        $filesystem->remove($this->tempDir);
+        return new OptimizedPathMappingRepository($store, $baseDirectory);
     }
 
     protected function createPrefilledRepository(Resource $root)


### PR DESCRIPTION
Fix https://github.com/puli/issues/issues/117.

This PR aims to implement a base directory for `PathMappingRepository` and `OptimizedPathMappingRepository` in order to store relative paths in the underlying key-value stores.

Here is the plan:
1. Put all the fixtures (even the temporary ones) in the `tests/Fixtures` directory **done**
2. Add testing for base directory check and stores **done**
3. Implement the feature to fix the tests **done**