### PR TITLE
Add Symfony 3 filesystem component in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "webmozart/key-value-store": "^1.0.0-beta5",
-        "symfony/filesystem": "^2.0",
+        "symfony/filesystem": "^2.0|^3.0",
         "phpunit/phpunit": "^4.6",
         "sebastian/version": "^1.0.1"
     },


### PR DESCRIPTION
After the release of Symfony 3 and the fact, that puli/repository is using the filesystem component, I added Symfony 3 support in composer.json.