### PR TITLE
Added a JSON schema for the generated mapping files

### DIFF
--- a/res/schema/path-mappings-schema-1.0.json
+++ b/res/schema/path-mappings-schema-1.0.json
@@ -1,0 +1,76 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "description": "A list of mappings from Puli paths to filesystem paths/other Puli paths.",
+    "definitions": {
+        "relativePath": {
+            "description": "A relative file system path.",
+            "type": "string",
+            "pattern": "^[^/]+(/[^/]+)*$"
+        },
+        "absolutePath": {
+            "description": "An absolute file system path.",
+            "type": "string",
+            "pattern": "^([a-zA-Z]:)?/(([^/]+/)*[^/]+)?$"
+        },
+        "filePath": {
+            "description": "A path of a file in the file system.",
+            "type": "string",
+            "oneOf": [
+                { "$ref": "#/definitions/relativePath" },
+                { "$ref": "#/definitions/absolutePath" }
+            ]
+        },
+        "directoryPath": {
+            "description": "A path of a directory in the file system.",
+            "type": "string",
+            "oneOf": [
+                { "$ref": "#/definitions/relativePath" },
+                { "$ref": "#/definitions/absolutePath" }
+            ]
+        },
+        "fileLink": {
+            "description": "A link to a file in the Puli repository. The target must be a file reference.",
+            "type": "string",
+            "pattern": "^@(/[^/]+)+$"
+        },
+        "directoryLink": {
+            "description": "A link to a directory in the Puli repository. The target must be a directory reference or a merged directory.",
+            "type": "string",
+            "pattern": "^@(/[^/]+)+$"
+        },
+        "fileReference": {
+            "description": "A reference to a single file or file link.",
+            "type": "string",
+            "oneOf": [
+                { "$ref": "#/definitions/filePath" },
+                { "$ref": "#/definitions/fileLink" }
+            ]
+        },
+        "directoryReference": {
+            "description": "A reference to a single directory or directory link.",
+            "type": "string",
+            "oneOf": [
+                { "$ref": "#/definitions/directoryPath" },
+                { "$ref": "#/definitions/directoryLink" }
+            ]
+        },
+        "mergedDirectory": {
+            "description": "A reference to multiple directories or directory links. The contents of these directories are merged. Files in later entries are preferred over those in earlier entries.",
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/definitions/directoryReference" },
+            "uniqueItems": true
+        }
+    },
+    "patternProperties": {
+        "^/(([^/]+/)*[^/]+)?+$": {
+            "oneOf": [
+                { "$ref": "#/definitions/fileReference" },
+                { "$ref": "#/definitions/directoryReference" },
+                { "$ref": "#/definitions/mergedDirectory" }
+            ]
+        }
+    },
+    "additionalProperties": false
+}


### PR DESCRIPTION
I created a JSON schema for the mapping files generated by the path mapping repositories. In the future, these repositories should make sure to comply to the schema so that we can safely consume mapping files with other tools, such as a JavaScript library.

ping @tgalopin 