### PR TITLE
Fix real files removal in FilesystemRepository::clear with symlinks enabled

### DIFF
--- a/src/FilesystemRepository.php
+++ b/src/FilesystemRepository.php
@@ -378,7 +378,7 @@ class FilesystemRepository extends AbstractEditableRepository
 
         ++$removed;
 
-        if (is_dir($filesystemPath)) {
+        if (is_dir($filesystemPath) && !is_link($filesystemPath)) {
             $iterator = $this->getDirectoryIterator($filesystemPath);
 
             foreach ($iterator as $childFilesystemPath) {

--- a/tests/AbstractFilesystemRepositorySymlinkTest.php
+++ b/tests/AbstractFilesystemRepositorySymlinkTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the puli/repository package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Puli\Repository\Tests;
+
+use Puli\Repository\Resource\DirectoryResource;
+use Symfony\Component\Filesystem\Filesystem;
+use Webmozart\Glob\Test\TestUtil;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+abstract class AbstractFilesystemRepositorySymlinkTest extends AbstractFilesystemRepositoryTest
+{
+    protected $tempBaseDir;
+
+    protected $tempDir;
+
+    /**
+     * Copy fixtures to temporary directory to prevent messing up the real
+     * fixtures when symlinks do not work.
+     */
+    protected $tempFixtures;
+
+    protected function setUp()
+    {
+        $this->markAsSkippedIfSymlinkIsMissing();
+
+        $this->tempBaseDir = TestUtil::makeTempDir('puli-repository', __CLASS__);
+
+        // Create both directories in the same directory, so that relative links
+        // work from one to the other
+        $this->tempDir = $this->tempBaseDir.'/workspace';
+        $this->tempFixtures = $this->tempBaseDir.'/fixtures';
+
+        mkdir($this->tempDir);
+        mkdir($this->tempFixtures);
+
+        $filesystem = new Filesystem();
+        $filesystem->mirror(__DIR__.'/Fixtures', $this->tempFixtures);
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $filesystem = new Filesystem();
+        $filesystem->remove($this->tempBaseDir);
+    }
+
+    public function testClearDirectoryLinksDoesNotRemoveChildrenFiles()
+    {
+        $this->writeRepo->add('/webmozart', new DirectoryResource($this->tempFixtures.'/dir2'));
+
+        $this->assertTrue($this->writeRepo->contains('/webmozart/file2'));
+        $this->assertTrue($this->writeRepo->contains('/webmozart/file3'));
+
+        $this->writeRepo->clear();
+
+        // We should not be able to access the resources
+        $this->assertFalse($this->writeRepo->contains('/webmozart/file2'));
+        $this->assertFalse($this->writeRepo->contains('/webmozart/file3'));
+
+        // But the files should still be here
+        $this->assertFileExists($this->tempFixtures.'/dir2/file2');
+        $this->assertFileExists($this->tempFixtures.'/dir2/file3');
+    }
+}

--- a/tests/FilesystemRepositoryAbsoluteSymlinkTest.php
+++ b/tests/FilesystemRepositoryAbsoluteSymlinkTest.php
@@ -16,52 +16,12 @@ use Puli\Repository\Api\Resource\PuliResource;
 use Puli\Repository\FilesystemRepository;
 use Puli\Repository\Resource\DirectoryResource;
 use Puli\Repository\Resource\FileResource;
-use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\Glob\Test\TestUtil;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractFilesystemRepositoryTest
+class FilesystemRepositoryAbsoluteSymlinkTest extends AbstractFilesystemRepositorySymlinkTest
 {
-    private $tempBaseDir;
-
-    private $tempDir;
-
-    /**
-     * Copy fixtures to temporary directory to prevent messing up the real
-     * fixtures when symlinks do not work.
-     */
-    private $tempFixtures;
-
-    protected function setUp()
-    {
-        $this->markAsSkippedIfSymlinkIsMissing();
-
-        $this->tempBaseDir = TestUtil::makeTempDir('puli-repository', __CLASS__);
-
-        // Create both directories in the same directory, so that relative links
-        // work from one to the other
-        $this->tempDir = $this->tempBaseDir.'/workspace';
-        $this->tempFixtures = $this->tempBaseDir.'/fixtures';
-
-        mkdir($this->tempDir);
-        mkdir($this->tempFixtures);
-
-        $filesystem = new Filesystem();
-        $filesystem->mirror(__DIR__.'/Fixtures', $this->tempFixtures);
-
-        parent::setUp();
-    }
-
-    protected function tearDown()
-    {
-        parent::tearDown();
-
-        $filesystem = new Filesystem();
-        $filesystem->remove($this->tempBaseDir);
-    }
-
     protected function createPrefilledRepository(PuliResource $root)
     {
         $repo = new FilesystemRepository($this->tempDir, true, false);

--- a/tests/FilesystemRepositoryRelativeSymlinkTest.php
+++ b/tests/FilesystemRepositoryRelativeSymlinkTest.php
@@ -16,52 +16,19 @@ use Puli\Repository\Api\Resource\PuliResource;
 use Puli\Repository\FilesystemRepository;
 use Puli\Repository\Resource\DirectoryResource;
 use Puli\Repository\Resource\FileResource;
-use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\Glob\Test\TestUtil;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class FilesystemRepositoryRelativeSymlinkTest extends AbstractEditableRepositoryTest
+class FilesystemRepositoryRelativeSymlinkTest extends AbstractFilesystemRepositorySymlinkTest
 {
-    private $tempBaseDir;
-
-    private $tempDir;
-
-    /**
-     * Copy fixtures to temporary directory to prevent messing up the real
-     * fixtures when symlinks do not work.
-     */
-    private $tempFixtures;
-
     protected function setUp()
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
             $this->markTestSkipped('Relative symbolic links are not supported on Windows.');
         }
 
-        $this->tempBaseDir = TestUtil::makeTempDir('puli-repository', __CLASS__);
-
-        // Create both directories in the same directory, so that relative links
-        // work from one to the other
-        $this->tempDir = $this->tempBaseDir.'/workspace';
-        $this->tempFixtures = $this->tempBaseDir.'/fixtures';
-
-        mkdir($this->tempDir);
-        mkdir($this->tempFixtures);
-
-        $filesystem = new Filesystem();
-        $filesystem->mirror(__DIR__.'/Fixtures', $this->tempFixtures);
-
         parent::setUp();
-    }
-
-    protected function tearDown()
-    {
-        parent::tearDown();
-
-        $filesystem = new Filesystem();
-        $filesystem->remove($this->tempBaseDir);
     }
 
     protected function createPrefilledRepository(PuliResource $root)


### PR DESCRIPTION
Fix puli/issues#178

The `build` cli command do two things: clear the repository and rebuild it. To clean the repository, the manager call the method `clear` of the configured repository (in our case FilsystemRepository).

In the FilesystemRepository, `clear` calls `removeResource` on all the resources in the repository. When using the FilesystemRepository with symlinks, it means `removeResource` is called on all the links present in `.puli/path-mappings`. However, `removeResource` is, for the moment, always recursive: all the children of the given path will be removed before trying to remove the path itself.

When trying to remove a directory link, `removeResource` list all its children to remove them: however, the children of a directory link are the real children in the filesystem. So the real files are removed.

This PR fixes this.