### PR TITLE
Handle "non-real" paths

### DIFF
--- a/src/FilesystemRepository.php
+++ b/src/FilesystemRepository.php
@@ -137,7 +137,7 @@ class FilesystemRepository extends AbstractEditableRepository
         Assert::boolean($symlink);
 
         $this->baseDir = rtrim(Path::canonicalize($baseDir), '/');
-        $this->baseDirLength = strlen($baseDir);
+        $this->baseDirLength = strlen($this->baseDir);
         $this->symlink = $symlink && self::isSymlinkSupported();
         $this->relative = $this->symlink && $relative;
         $this->filesystem = new Filesystem();

--- a/tests/FilesystemRepositoryCopyTest.php
+++ b/tests/FilesystemRepositoryCopyTest.php
@@ -191,4 +191,13 @@ class FilesystemRepositoryCopyTest extends AbstractEditableRepositoryTest
     {
         $this->writeRepo->add('/webmozart/link', new LinkResource('/webmozart/puli/file'));
     }
+
+    public function testNonRealPath()
+    {
+        $repository = new FilesystemRepository(__DIR__ . '/Fixtures/dir5/sub/..');
+        $children = $repository->listChildren('/');
+        $children = iterator_to_array($children);
+        $this->assertArrayHasKey(0, $children);
+        $this->assertEquals('file1', $children[0]->getName());
+    }
 }


### PR DESCRIPTION
Use the resolved absolute path to determine the resource name.
